### PR TITLE
Prevent layout shifting by wrapping cover widgets in a fixed container

### DIFF
--- a/opdsgridmenuplus.lua
+++ b/opdsgridmenuplus.lua
@@ -187,21 +187,29 @@ function OPDSGridCell:init()
     }
 
     -- Create cover widget
-    local cover_widget
+    local inner_cover_widget
     if self.entry.cover_bb then
-        cover_widget = ImageWidget:new {
+        inner_cover_widget = ImageWidget:new {
             image = self.entry.cover_bb,
             width = self.cover_width,
             height = self.cover_height,
             alpha = true,
         }
     elseif self.entry.cover_url and self.entry.lazy_load_cover then
-        cover_widget = createGridPlaceholder(self.cover_width, self.cover_height, "loading")
+        inner_cover_widget = createGridPlaceholder(self.cover_width, self.cover_height, "loading")
     elseif self.entry.cover_url and self.entry.cover_failed then
-        cover_widget = createGridPlaceholder(self.cover_width, self.cover_height, "error")
+        inner_cover_widget = createGridPlaceholder(self.cover_width, self.cover_height, "error")
     else
-        cover_widget = createGridPlaceholder(self.cover_width, self.cover_height, "no_cover")
+        inner_cover_widget = createGridPlaceholder(self.cover_width, self.cover_height, "no_cover")
     end
+
+    local cover_widget = CenterContainer:new {
+        dimen = Geom:new {
+            w = self.cover_width,
+            h = self.cover_height,
+        },
+        inner_cover_widget
+    }
 
     -- Parse title and author
     local title, author = parseTitleAuthor(self.entry)

--- a/opdslistmenuplus.lua
+++ b/opdslistmenuplus.lua
@@ -220,23 +220,32 @@ function OPDSListMenuItem:init()
         },
     }
 
-    local cover_widget
+    local inner_cover_widget
 
     -- Check if we should use real cover or placeholder
     if self.entry.cover_bb then
-        cover_widget = ImageWidget:new {
+        inner_cover_widget = ImageWidget:new {
             image = self.entry.cover_bb,
             width = self.cover_width,
             height = self.cover_height,
             alpha = true,
         }
     elseif self.entry.cover_url and self.entry.lazy_load_cover then
-        cover_widget = createPlaceholderCover(self.cover_width, self.cover_height, "loading")
+        inner_cover_widget = createPlaceholderCover(self.cover_width, self.cover_height, "loading")
     elseif self.entry.cover_url and self.entry.cover_failed then
-        cover_widget = createPlaceholderCover(self.cover_width, self.cover_height, "error")
+        inner_cover_widget = createPlaceholderCover(self.cover_width, self.cover_height, "error")
     else
-        cover_widget = createPlaceholderCover(self.cover_width, self.cover_height, "no_cover")
+        inner_cover_widget = createPlaceholderCover(self.cover_width, self.cover_height, "no_cover")
     end
+
+    -- Wrap in a fixed container to prevent layout shifting during updates
+    local cover_widget = CenterContainer:new {
+        dimen = Geom:new {
+            w = self.cover_width,
+            h = self.cover_height,
+        },
+        inner_cover_widget
+    }
 
     -- Calculate spacing and dimensions
     local top_padding = COVER_CONFIG.item_top_padding


### PR DESCRIPTION


Thanks for contributing to OPDS Plus!



## Summary



Prevent layout shifting by wrapping cover widgets in a fixed container.



## Type of change



- [x] Bug fix

- [ ] New feature

- [ ] UI/UX improvement

- [ ] Refactor / code cleanup

- [ ] Documentation update



## Checklist



- [x] I have tested these changes on my device (or emulator)

- [x] I have checked for Lua errors in `crash.log`

- [x] I have updated the README/CHANGELOG if needed

- [x] I have kept changes focused and minimal



## Screenshots



If this PR affects the UI, please include before/after screenshots.



## Additional notes



Add any additional notes, edge cases, or follow-up ideas.

