### PR TITLE
refactor: add BrowserContext factory to eliminate DRY violations

### DIFF
--- a/core/browser_context.lua
+++ b/core/browser_context.lua
@@ -1,0 +1,96 @@
+-- Browser Context Factory for OPDS Browser
+-- Centralizes creation of context objects passed to navigation and parsing functions
+-- This eliminates repeated context building code (DRY principle)
+
+local BrowserContext = {}
+
+--- Create a parsing/navigation context from browser state
+-- This context is passed to NavigationHandler and FeedFetcher functions
+-- @param browser table OPDSBrowser instance or table with required fields
+-- @return table Context object with all OPDS type constants and auth info
+function BrowserContext.fromBrowser(browser)
+	return {
+		-- OPDS MIME type patterns
+		catalog_type = browser.catalog_type,
+		search_type = browser.search_type,
+		search_template_type = browser.search_template_type,
+
+		-- Relationship type patterns
+		acquisition_rel = browser.acquisition_rel,
+		borrow_rel = browser.borrow_rel,
+		stream_rel = browser.stream_rel,
+		facet_rel = browser.facet_rel,
+
+		-- Image relationship types
+		thumbnail_rel = browser.thumbnail_rel,
+		image_rel = browser.image_rel,
+
+		-- Runtime state
+		sync = browser.sync,
+
+		-- Authentication
+		username = browser.root_catalog_username,
+		password = browser.root_catalog_password,
+	}
+end
+
+--- Create a minimal context for unauthenticated requests
+-- Useful for public catalogs or initial discovery
+-- @param browser table OPDSBrowser instance with type constants
+-- @return table Context object without authentication
+function BrowserContext.anonymous(browser)
+	local context = BrowserContext.fromBrowser(browser)
+	context.username = nil
+	context.password = nil
+	return context
+end
+
+--- Create a context with custom authentication
+-- Useful when credentials differ from browser's root catalog
+-- @param browser table OPDSBrowser instance with type constants
+-- @param username string|nil Username for HTTP auth
+-- @param password string|nil Password for HTTP auth
+-- @return table Context object with custom credentials
+function BrowserContext.withAuth(browser, username, password)
+	local context = BrowserContext.fromBrowser(browser)
+	context.username = username
+	context.password = password
+	return context
+end
+
+--- Create a context for sync operations
+-- Sets sync flag to true, which affects parsing behavior
+-- @param browser table OPDSBrowser instance
+-- @return table Context object with sync mode enabled
+function BrowserContext.forSync(browser)
+	local context = BrowserContext.fromBrowser(browser)
+	context.sync = true
+	return context
+end
+
+--- Validate that a context has all required fields
+-- @param context table Context object to validate
+-- @return boolean, string|nil True if valid, false + error message if invalid
+function BrowserContext.validate(context)
+	local required_fields = {
+		"catalog_type",
+		"search_type",
+		"search_template_type",
+		"acquisition_rel",
+		"borrow_rel",
+		"stream_rel",
+		"facet_rel",
+		"thumbnail_rel",
+		"image_rel",
+	}
+
+	for _, field in ipairs(required_fields) do
+		if context[field] == nil then
+			return false, "Missing required field: " .. field
+		end
+	end
+
+	return true
+end
+
+return BrowserContext

--- a/core/navigation_handler.lua
+++ b/core/navigation_handler.lua
@@ -8,6 +8,7 @@ local _ = require("gettext")
 
 local Constants = require("models.constants")
 local OPDSUtils = require("opds_utils")
+local BrowserContext = require("core.browser_context")
 
 local NavigationHandler = {}
 
@@ -214,29 +215,17 @@ function NavigationHandler.updateCatalog(item_url, browser, paths_updated)
 		browser:_debugLog("updateCatalog called for:", item_url)
 	end
 
+	local context = BrowserContext.fromBrowser(browser)
+	local debug_callback = function(...) if browser._debugLog then browser:_debugLog(...) end end
+
 	local menu_table = FeedFetcher.genItemTableFromURL(
 		item_url,
-		browser.root_catalog_username,
-		browser.root_catalog_password,
-		function(...) if browser._debugLog then browser:_debugLog(...) end end,
+		context.username,
+		context.password,
+		debug_callback,
 		function(catalog, url)
-			local context = {
-				catalog_type = browser.catalog_type,
-				search_type = browser.search_type,
-				search_template_type = browser.search_template_type,
-				acquisition_rel = browser.acquisition_rel,
-				borrow_rel = browser.borrow_rel,
-				stream_rel = browser.stream_rel,
-				facet_rel = browser.facet_rel,
-				thumbnail_rel = browser.thumbnail_rel,
-				image_rel = browser.image_rel,
-				sync = browser.sync,
-				username = browser.root_catalog_username,
-				password = browser.root_catalog_password,
-			}
 			local items, facets, search = NavigationHandler.genItemTableFromCatalog(
-				catalog, url, context,
-				function(...) if browser._debugLog then browser:_debugLog(...) end end)
+				catalog, url, context, debug_callback)
 			browser.facet_groups = facets
 			browser.search_url = search
 			return items
@@ -296,30 +285,18 @@ end
 function NavigationHandler.appendCatalog(item_url, browser)
 	local FeedFetcher = require("core.feed_fetcher")
 
+	local context = BrowserContext.fromBrowser(browser)
+	local debug_callback = function(...) if browser._debugLog then browser:_debugLog(...) end end
+
 	local menu_table = FeedFetcher.genItemTableFromURL(
 		item_url,
-		browser.root_catalog_username,
-		browser.root_catalog_password,
-		function(...) if browser._debugLog then browser:_debugLog(...) end end,
+		context.username,
+		context.password,
+		debug_callback,
 		function(catalog, url)
-			local context = {
-				catalog_type = browser.catalog_type,
-				search_type = browser.search_type,
-				search_template_type = browser.search_template_type,
-				acquisition_rel = browser.acquisition_rel,
-				borrow_rel = browser.borrow_rel,
-				stream_rel = browser.stream_rel,
-				facet_rel = browser.facet_rel,
-				thumbnail_rel = browser.thumbnail_rel,
-				image_rel = browser.image_rel,
-				sync = browser.sync,
-				username = browser.root_catalog_username,
-				password = browser.root_catalog_password,
-			}
 			-- luacheck: ignore facets search
 			local items, facets, search = NavigationHandler.genItemTableFromCatalog(
-				catalog, url, context,
-				function(...) if browser._debugLog then browser:_debugLog(...) end end)
+				catalog, url, context, debug_callback)
 			return items
 		end
 	)

--- a/ui/browser.lua
+++ b/ui/browser.lua
@@ -38,6 +38,9 @@ local CatalogManager = require("core.catalog_manager")
 -- Import the navigation handler
 local NavigationHandler = require("core.navigation_handler")
 
+-- Import the browser context factory
+local BrowserContext = require("core.browser_context")
+
 -- Import the debug utility
 local Debug = require("utils.debug")
 
@@ -201,20 +204,7 @@ function OPDSBrowser:genItemTableFromURL(item_url)
 end
 
 function OPDSBrowser:genItemTableFromCatalog(catalog, item_url)
-    local context = {
-        catalog_type = self.catalog_type,
-        search_type = self.search_type,
-        search_template_type = self.search_template_type,
-        acquisition_rel = self.acquisition_rel,
-        borrow_rel = self.borrow_rel,
-        stream_rel = self.stream_rel,
-        facet_rel = self.facet_rel,
-        thumbnail_rel = self.thumbnail_rel,
-        image_rel = self.image_rel,
-        sync = self.sync,
-        username = self.root_catalog_username,
-        password = self.root_catalog_password,
-    }
+    local context = BrowserContext.fromBrowser(self)
 
     local item_table, facet_groups, search_url = NavigationHandler.genItemTableFromCatalog(
         catalog, item_url, context,


### PR DESCRIPTION
- Create core/browser_context.lua with factory methods:
  - fromBrowser(): creates context from browser instance
  - anonymous(): creates unauthenticated context
  - withAuth(): creates context with custom credentials
  - forSync(): creates context with sync mode enabled
  - validate(): validates context has required fields

- Update navigation_handler.lua to use BrowserContext:
  - updateCatalog() now uses BrowserContext.fromBrowser()
  - appendCatalog() now uses BrowserContext.fromBrowser()
  - Extract debug_callback to avoid duplication

- Update ui/browser.lua to use BrowserContext:
  - genItemTableFromCatalog() now uses BrowserContext.fromBrowser()
  - Add import for browser_context module

This eliminates 3 instances of duplicated 13-line context object
creation, improving maintainability and reducing potential for
inconsistencies when context fields change.