### PR TITLE
feat: Add StateManager for centralized state change tracking

### DIFF
--- a/core/download_manager.lua
+++ b/core/download_manager.lua
@@ -20,6 +20,7 @@ local N_ = _.ngettext
 local T = require("ffi/util").template
 
 local Constants = require("models.constants")
+local StateManager = require("core.state_manager")
 
 local DownloadManager = {}
 
@@ -197,7 +198,7 @@ function DownloadManager.downloadDownloadList(browser)
 	if dl_count > 0 then
 		browser:updateDownloadListItemTable()
 		browser.download_list_updated = true
-		browser._manager.updated = true
+		StateManager.getInstance():markDirty()
 		UIManager:show(InfoMessage:new {
 			text = T(N_("1 book downloaded", "%1 books downloaded", dl_count), dl_count)
 		})
@@ -276,7 +277,7 @@ function DownloadManager.downloadPendingSyncs(browser, dl_list)
 			})
 		end
 
-		browser._manager.updated = true
+		StateManager.getInstance():markDirty()
 		return duplicate_list
 	end
 
@@ -288,7 +289,7 @@ end
 -- @param download_item table Item with file, url, username, password, info, catalog
 function DownloadManager.addToDownloadQueue(browser, download_item)
 	table.insert(browser.downloads, download_item)
-	browser._manager.updated = true
+	StateManager.getInstance():markDirty()
 end
 
 -- Remove item from download queue
@@ -296,7 +297,7 @@ end
 -- @param index number Index of item to remove
 function DownloadManager.removeFromDownloadQueue(browser, index)
 	table.remove(browser.downloads, index)
-	browser._manager.updated = true
+	StateManager.getInstance():markDirty()
 end
 
 -- Clear all items from download queue
@@ -306,7 +307,7 @@ function DownloadManager.clearDownloadQueue(browser)
 		browser.downloads[i] = nil
 	end
 	browser.download_list_updated = true
-	browser._manager.updated = true
+	StateManager.getInstance():markDirty()
 end
 
 return DownloadManager

--- a/core/state_manager.lua
+++ b/core/state_manager.lua
@@ -1,0 +1,157 @@
+-- State Manager for OPDS Plus
+-- Centralizes state change tracking and persistence notifications
+-- Reduces direct _manager.updated coupling throughout the codebase
+
+local StateManager = {}
+StateManager.__index = StateManager
+
+-- Singleton instance
+local instance = nil
+
+--- Get or create the StateManager singleton
+-- @param plugin table Optional plugin instance to initialize with
+-- @return StateManager
+function StateManager.getInstance(plugin)
+	if not instance then
+		instance = setmetatable({
+			_plugin = plugin,
+			_dirty = false,
+			_change_listeners = {},
+		}, StateManager)
+	elseif plugin then
+		instance._plugin = plugin
+	end
+	return instance
+end
+
+--- Reset the singleton (primarily for testing)
+function StateManager.reset()
+	instance = nil
+end
+
+--- Initialize with a plugin instance
+-- @param plugin table Plugin instance (OPDS main module)
+function StateManager:init(plugin)
+	self._plugin = plugin
+	self._dirty = false
+end
+
+--- Mark state as changed (needs persistence)
+-- This replaces scattered `browser._manager.updated = true` calls
+function StateManager:markDirty()
+	self._dirty = true
+	if self._plugin then
+		self._plugin.updated = true
+	end
+	self:_notifyListeners("dirty")
+end
+
+--- Check if state has unsaved changes
+-- @return boolean True if there are unsaved changes
+function StateManager:isDirty()
+	return self._dirty
+end
+
+--- Clear the dirty flag (after save)
+function StateManager:markClean()
+	self._dirty = false
+	self:_notifyListeners("clean")
+end
+
+--- Get the current settings data
+-- @return table Settings data table
+function StateManager:getSettings()
+	if self._plugin and self._plugin.settings then
+		return self._plugin.settings
+	end
+	return {}
+end
+
+--- Get a specific setting value
+-- @param key string Setting key
+-- @param default any Default value if not set
+-- @return any Setting value or default
+function StateManager:getSetting(key, default)
+	local settings = self:getSettings()
+	if settings[key] ~= nil then
+		return settings[key]
+	end
+	return default
+end
+
+--- Update a setting value and mark dirty
+-- @param key string Setting key
+-- @param value any Value to set
+function StateManager:setSetting(key, value)
+	local settings = self:getSettings()
+	settings[key] = value
+	self:markDirty()
+end
+
+--- Check if debug mode is enabled
+-- @return boolean True if debug mode is on
+function StateManager:isDebugMode()
+	return self:getSetting("debug_mode", false)
+end
+
+--- Get display mode (list/grid)
+-- @return string "list" or "grid"
+function StateManager:getDisplayMode()
+	return self:getSetting("display_mode", "list")
+end
+
+--- Set display mode
+-- @param mode string "list" or "grid"
+function StateManager:setDisplayMode(mode)
+	self:setSetting("display_mode", mode)
+	-- Also persist immediately for display mode changes
+	if self._plugin and self._plugin.opds_settings then
+		self._plugin.opds_settings:saveSetting("settings", self:getSettings())
+		self._plugin.opds_settings:flush()
+	end
+end
+
+--- Get sync directory
+-- @return string|nil Sync directory path or nil
+function StateManager:getSyncDir()
+	return self:getSetting("sync_dir")
+end
+
+--- Get maximum sync downloads
+-- @return number Maximum downloads (default 50)
+function StateManager:getMaxSyncDownloads()
+	local Constants = require("models.constants")
+	return self:getSetting("sync_max_dl", Constants.SYNC.DEFAULT_MAX_DOWNLOADS)
+end
+
+--- Get filetypes filter string
+-- @return string|nil Filetypes string or nil
+function StateManager:getFiletypes()
+	return self:getSetting("filetypes")
+end
+
+--- Register a listener for state changes
+-- @param listener function Callback function(event_type)
+-- @return number Listener ID for removal
+function StateManager:addChangeListener(listener)
+	table.insert(self._change_listeners, listener)
+	return #self._change_listeners
+end
+
+--- Remove a change listener
+-- @param listener_id number ID returned from addChangeListener
+function StateManager:removeChangeListener(listener_id)
+	self._change_listeners[listener_id] = nil
+end
+
+--- Internal: notify all listeners of state change
+-- @param event_type string Type of event ("dirty" or "clean")
+function StateManager:_notifyListeners(event_type)
+	for _, listener in pairs(self._change_listeners) do
+		if type(listener) == "function" then
+			pcall(listener, event_type)
+		end
+	end
+end
+
+return StateManager

--- a/core/sync_manager.lua
+++ b/core/sync_manager.lua
@@ -14,6 +14,7 @@ local _ = require("gettext")
 
 local Constants = require("models.constants")
 local DownloadManager = require("core.download_manager")
+local StateManager = require("core.state_manager")
 
 local SyncManager = {}
 
@@ -34,7 +35,7 @@ function SyncManager.showMaxSyncDialog(browser)
 		ok_text = _("Save"),
 		callback = function(spin)
 			browser.settings.sync_max_dl = spin.value
-			browser._manager.updated = true
+			StateManager.getInstance():markDirty()
 		end,
 	}
 	UIManager:show(spin)
@@ -52,7 +53,7 @@ function SyncManager.showSyncDirChooser(browser)
 		onConfirm = function(inbox)
 			logger.info("set opds sync folder", inbox)
 			browser.settings.sync_dir = inbox
-			browser._manager.updated = true
+			StateManager.getInstance():markDirty()
 		end,
 	}:chooseDir(force_chooser_dir)
 end
@@ -82,7 +83,7 @@ function SyncManager.showFiletypesDialog(browser)
 					callback = function()
 						local str = dialog:getInputText()
 						browser.settings.filetypes = str ~= "" and str or nil
-						browser._manager.updated = true
+						StateManager.getInstance():markDirty()
 						UIManager:close(dialog)
 					end,
 				},

--- a/main.lua
+++ b/main.lua
@@ -20,6 +20,9 @@ local SettingsMenu = require("config.settings_menu")
 -- Import settings dialogs
 local SettingsDialogs = require("ui.dialogs.settings_dialogs")
 
+-- Import state manager
+local StateManager = require("core.state_manager")
+
 local OPDS = WidgetContainer:extend {
     name = "opdsplus",
     opds_settings_file = DataStorage:getSettingsDir() .. "/opdsplus.lua",
@@ -40,6 +43,9 @@ function OPDS:init()
     if settings_manager.is_first_run then
         self.updated = true -- first run, force flush
     end
+
+    -- Initialize state manager singleton
+    StateManager.getInstance(self)
 
     -- Load servers, downloads, and pending syncs
     self.servers = self.opds_settings:readSetting("servers", Constants.DEFAULT_SERVERS)

--- a/ui/dialogs/menu_builder.lua
+++ b/ui/dialogs/menu_builder.lua
@@ -13,6 +13,7 @@ local _ = require("gettext")
 local T = ffiUtil.template
 
 local Constants = require("models.constants")
+local StateManager = require("core.state_manager")
 
 local OPDSMenuBuilder = {}
 
@@ -95,7 +96,7 @@ function OPDSMenuBuilder.buildFacetMenu(browser, catalog_url, has_covers)
 
 	-- Add view toggle option FIRST if we have covers
 	if has_covers then
-		local current_mode = browser._manager.settings.display_mode or "list"
+		local current_mode = StateManager.getInstance():getDisplayMode()
 		local toggle_text
 		if current_mode == "list" then
 			toggle_text = Constants.ICONS.GRID_VIEW .. " " .. _("Switch to Grid View")
@@ -188,7 +189,7 @@ function OPDSMenuBuilder.buildCatalogMenu(browser, catalog_url, has_covers)
 
 	-- Add view toggle if we have covers
 	if has_covers then
-		local current_mode = browser._manager.settings.display_mode or "list"
+		local current_mode = StateManager.getInstance():getDisplayMode()
 		local toggle_text
 		if current_mode == "list" then
 			toggle_text = Constants.ICONS.GRID_VIEW .. " " .. _("Switch to Grid View")


### PR DESCRIPTION
Introduces StateManager singleton to decouple state management from
direct _manager access throughout the codebase.

New file:
- core/state_manager.lua: Singleton pattern for state management
  - markDirty()/markClean()/isDirty() for change tracking
  - getSetting()/setSetting() for settings access
  - Convenience methods: getDisplayMode(), setDisplayMode(),
    getSyncDir(), getMaxSyncDownloads(), getFiletypes(), isDebugMode()
  - Change listener support for future event-driven patterns

Updates:
- main.lua: Initialize StateManager singleton on plugin init
- core/download_manager.lua: Replace _manager.updated with StateManager
- core/sync_manager.lua: Replace _manager.updated with StateManager
- ui/browser.lua: Use StateManager for toggleViewMode() and updates
- ui/dialogs/menu_builder.lua: Use StateManager for display mode checks

Benefits:
- Decouples modules from direct plugin manager access
- Centralized state change tracking (no scattered .updated = true)
- Foundation for cleaner settings management
- Change listener support enables future event-driven patterns
- Maintains backward compatibility - _manager still accessible