### PR TITLE
refactor: decouple Debug utility from manager dependency

### DIFF
--- a/ui/browser.lua
+++ b/ui/browser.lua
@@ -79,7 +79,7 @@ function OPDSBrowser:init()
 end
 
 function OPDSBrowser:_debugLog(...)
-    Debug.log(self._manager, "Browser:", ...)
+    Debug.log("Browser:", ...)
 end
 
 function OPDSBrowser:toggleViewMode()

--- a/ui/menus/cover_menu.lua
+++ b/ui/menus/cover_menu.lua
@@ -16,7 +16,7 @@ function OPDSCoverMenu:init()
 end
 
 function OPDSCoverMenu:_debugLog(...)
-    Debug.log(self._manager, "CoverMenu:", ...)
+    Debug.log("CoverMenu:", ...)
 end
 
 function OPDSCoverMenu:updateItems(select_number)

--- a/utils/debug.lua
+++ b/utils/debug.lua
@@ -1,29 +1,75 @@
 -- Debug utility for OPDS Plus
--- Provides conditional debug logging based on settings
+-- Provides conditional debug logging based on StateManager settings
 
 local logger = require("logger")
 
 local Debug = {}
 
---- Log debug message if debug mode is enabled
--- @param manager table Plugin manager instance with settings
+-- Lazy-load StateManager to avoid circular dependencies
+local function getStateManager()
+	local StateManager = require("core.state_manager")
+	return StateManager.getInstance()
+end
+
+--- Check if debug mode is enabled
+-- @return boolean True if debug mode is on
+local function isDebugEnabled()
+	local state = getStateManager()
+	return state:isDebugMode()
+end
+
+--- Log debug message if debug mode is enabled (StateManager-based)
+-- No manager parameter needed - uses StateManager singleton
+-- @param prefix string Log prefix (e.g., "Browser:", "DownloadMgr:")
 -- @param ... any Values to log
-function Debug.log(manager, ...)
-	if manager and manager.settings and manager.settings.debug_mode then
-		logger.dbg("OPDS+:", ...)
+function Debug.log(prefix, ...)
+	if isDebugEnabled() then
+		logger.dbg("OPDS+", prefix, ...)
+	end
+end
+
+--- Legacy log function for backward compatibility
+-- Accepts manager as first param but ignores it, uses StateManager instead
+-- @param manager table|nil Plugin manager instance (ignored, kept for compatibility)
+-- @param prefix string Log prefix
+-- @param ... any Values to log
+function Debug.logCompat(manager, prefix, ...)
+	-- Ignore manager param, use StateManager
+	if isDebugEnabled() then
+		logger.dbg("OPDS+", prefix, ...)
 	end
 end
 
 --- Create a debug logger function bound to a specific context
+-- Uses StateManager instead of requiring manager to be passed
 -- @param context string Context identifier (e.g., "Browser", "DownloadMgr")
--- @param manager table Plugin manager instance with settings
 -- @return function Debug logging function
-function Debug.createLogger(context, manager)
+function Debug.createLogger(context)
+	local prefix = "[" .. context .. "]:"
 	return function(...)
-		if manager and manager.settings and manager.settings.debug_mode then
-			logger.dbg("OPDS+ [" .. context .. "]:", ...)
+		if isDebugEnabled() then
+			logger.dbg("OPDS+", prefix, ...)
 		end
 	end
+end
+
+--- Create a debug logger with method-style calling
+-- Returns an object with a log method for OOP-style usage
+-- @param context string Context identifier
+-- @return table Object with log method
+function Debug.createContextLogger(context)
+	local prefix = "[" .. context .. "]:"
+	return {
+		log = function(self, ...)
+			if isDebugEnabled() then
+				logger.dbg("OPDS+", prefix, ...)
+			end
+		end,
+		--- Check if debug is enabled (useful for expensive debug operations)
+		isEnabled = function()
+			return isDebugEnabled()
+		end,
+	}
 end
 
 return Debug


### PR DESCRIPTION
Update debug logging to use StateManager singleton instead of requiring
manager instance to be passed to each call.

Changes to utils/debug.lua:
- Debug.log(prefix, ...) - new clean API using StateManager
- Debug.logCompat(manager, prefix, ...) - legacy compatibility
- Debug.createLogger(context) - simplified factory (no manager param)
- Debug.createContextLogger(context) - new OOP-style logger factory

Benefits:
- Eliminates manager coupling in debug calls
- Simpler API: Debug.log("Context:", ...) vs Debug.log(self._manager, "Context:", ...)
- Centralized debug mode check via StateManager.getInstance():isDebugMode()
- Lazy-loads StateManager to avoid circular dependencies

Updated consumers:
- ui/browser.lua - simplified _debugLog method
- ui/menus/cover_menu.lua - simplified _debugLog method