### PR TITLE
refactor: use Debug utility in list and grid menus

### DIFF
--- a/ui/menus/grid_menu.lua
+++ b/ui/menus/grid_menu.lua
@@ -18,10 +18,10 @@ local VerticalSpan = require("ui/widget/verticalspan")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local LineWidget = require("ui/widget/linewidget")
 local Screen = Device.screen
-local logger = require("logger")
 local _ = require("gettext")
 
 local CoverLoader = require("services.cover_loader")
+local Debug = require("utils.debug")
 local StateManager = require("core.state_manager")
 
 -- ============================================
@@ -333,9 +333,7 @@ local OPDSGridMenu = Menu:extend {
 }
 
 function OPDSGridMenu:_debugLog(...)
-    if StateManager.getInstance():isDebugMode() then
-        logger.dbg("OPDS+ Grid:", ...)
-    end
+    Debug.log("Grid:", ...)
 end
 
 function OPDSGridMenu:setGridDimensions()

--- a/ui/menus/list_menu.lua
+++ b/ui/menus/list_menu.lua
@@ -18,10 +18,10 @@ local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local Screen = Device.screen
-local logger = require("logger")
 local _ = require("gettext")
 
 local CoverLoader = require("services.cover_loader")
+local Debug = require("utils.debug")
 local StateManager = require("core.state_manager")
 
 -- ============================================
@@ -319,9 +319,7 @@ local OPDSListMenu = Menu:extend {
 }
 
 function OPDSListMenu:_debugLog(...)
-    if StateManager.getInstance():isDebugMode() then
-        logger.dbg("OPDS+ List:", ...)
-    end
+    Debug.log("List:", ...)
 end
 
 -- Calculate and set cover dimensions based on available space


### PR DESCRIPTION
## Summary

Update list and grid menu components to use the centralized `Debug` utility for consistent debug logging.

## Changes Made

### `ui/menus/list_menu.lua`
- Replace `logger` import with `Debug` utility
- Simplify `_debugLog()` from 3 lines to 1 line
- Remove direct `StateManager.isDebugMode()` check (handled by Debug)

```lua
-- Before
function OPDSListMenu:_debugLog(...)
    if StateManager.getInstance():isDebugMode() then
        logger.dbg("OPDS+ List:", ...)
    end
end

-- After
function OPDSListMenu:_debugLog(...)
    Debug.log("List:", ...)
end
```

### `ui/menus/grid_menu.lua`
- Same changes as list_menu.lua

## Stats
- **2 files changed**: 4 insertions, 8 deletions (net -4 lines)

## Benefits
- ✅ Consistent debug logging across all UI components
- ✅ Centralized debug mode control via Debug utility
- ✅ Simpler, more readable code
- ✅ Removes unused `logger` imports

## Testing Checklist
- [ ] List view displays and functions correctly
- [ ] Grid view displays and functions correctly
- [ ] Debug messages appear in log when debug_mode is enabled
- [ ] No debug messages when debug_mode is disabled