### PR TITLE
Add option for larger cover images #56

### DIFF
--- a/config/settings_menu.lua
+++ b/config/settings_menu.lua
@@ -21,6 +21,20 @@ function SettingsMenu.create(plugin)
 					text = _("Display Mode"),
 					sub_item_table = {
 						{
+							text = _("Prefer Large Covers"),
+							checked_func = function()
+								if plugin.opds_settings:isTrue("large_cover") then
+									return true
+								else
+									return false
+								end
+							end,
+							callback = function()
+								plugin.opds_settings:flipNilOrFalse("large_cover")
+								plugin.opds_settings:flush()
+							end,
+						},
+						{
 							text = _("List View"),
 							checked_func = function()
 								local mode = plugin.settings.display_mode
@@ -94,8 +108,8 @@ function SettingsMenu.create(plugin)
 								plugin:saveSetting("use_same_font", not current)
 								UIManager:show(InfoMessage:new {
 									text = not current and
-										_("Now using the same font for title and details.\n\nChanges apply on next catalog browse.") or
-										_("Now using separate fonts for title and details.\n\nChanges apply on next catalog browse."),
+											_("Now using the same font for title and details.\n\nChanges apply on next catalog browse.") or
+											_("Now using separate fonts for title and details.\n\nChanges apply on next catalog browse."),
 									timeout = 2,
 								})
 							end,
@@ -125,8 +139,8 @@ function SettingsMenu.create(plugin)
 										plugin:saveSetting("title_bold", not current)
 										UIManager:show(InfoMessage:new {
 											text = not current and
-												_("Title is now bold.") or
-												_("Title is now regular weight."),
+													_("Title is now bold.") or
+													_("Title is now regular weight."),
 											timeout = 2,
 										})
 									end,
@@ -162,8 +176,8 @@ function SettingsMenu.create(plugin)
 										plugin:saveSetting("info_bold", not current)
 										UIManager:show(InfoMessage:new {
 											text = not current and
-												_("Information text is now bold.") or
-												_("Information text is now regular weight."),
+													_("Information text is now bold.") or
+													_("Information text is now regular weight."),
 											timeout = 2,
 										})
 									end,
@@ -217,8 +231,8 @@ function SettingsMenu.create(plugin)
 								plugin.opds_settings:flush()
 								UIManager:show(InfoMessage:new {
 									text = plugin.settings.debug_mode and
-										_("Debug mode enabled.\n\nDetailed logging is now active.") or
-										_("Debug mode disabled.\n\nNormal logging restored."),
+											_("Debug mode enabled.\n\nDetailed logging is now active.") or
+											_("Debug mode disabled.\n\nNormal logging restored."),
 									timeout = 2,
 								})
 							end,

--- a/core/navigation_handler.lua
+++ b/core/navigation_handler.lua
@@ -139,7 +139,7 @@ function NavigationHandler.genItemTableFromCatalog(catalog, item_url, browser_co
 
 					-- Special handling for PDF links
 					if link.title == "pdf" or link.type == "application/pdf"
-						and link.rel ~= "subsection" then
+							and link.rel ~= "subsection" then
 						local original_href = link.href
 						local parsed = socket_url.parse(original_href)
 						if not parsed then parsed = { path = original_href } end
@@ -183,8 +183,17 @@ function NavigationHandler.genItemTableFromCatalog(catalog, item_url, browser_co
 				debug_callback("Book entry with cover:", title)
 			end
 
-			-- Prefer thumbnail over full image for performance
-			if item.thumbnail then
+			local DataStorage = require("datastorage")
+			local opds_settings_file = DataStorage:getSettingsDir() .. "/opdsplus.lua"
+			local Settings = require("config.settings")
+			local settings_manager = Settings:new(opds_settings_file)
+			local opds_settings = settings_manager.storage
+
+			-- Prefer thumbnail over full image for performance unless told otherwise
+			if opds_settings:readSetting("large_cover") and item.image then
+				item.cover_url = item.image
+				item.lazy_load_cover = true
+			elseif item.thumbnail then
 				item.cover_url = item.thumbnail
 				item.lazy_load_cover = true
 			elseif item.image then


### PR DESCRIPTION
# OPDS Plus Pull Request

Thanks for contributing to OPDS Plus!

## Summary

Cover images are grainy when connecting to some OPDS servers because the plugin isn't pulling the full image. Patch adds menu option to download larger images for pretty covers. Issue #56 

## Type of change

- [ ] Bug fix
- [X] New feature
- [X] UI/UX improvement
- [ ] Refactor / code cleanup
- [ ] Documentation update

## Checklist

- [X] I have tested these changes on my device (or emulator)
- [X] I have checked for Lua errors in `crash.log`
- [X] I have updated the README/CHANGELOG if needed
- [X] I have kept changes focused and minimal

## Screenshots

If this PR affects the UI, please include before/after screenshots.

## Additional notes

Last one for the day, sorry I didn't submit these properly originally