### PR TITLE
Issue #56: larger cover option + disk cache controls + subprocess-safe loader

### DIFF
--- a/config/settings.lua
+++ b/config/settings.lua
@@ -72,6 +72,19 @@ function Settings:initializeDefaults()
 	if not self.data.cover_size_preset then
 		self.data.cover_size_preset = "Regular"
 	end
+	if self.data.prefer_large_covers == nil then
+		-- Migrate legacy raw setting key if present.
+		self.data.prefer_large_covers = self.storage:readSetting("large_cover") == true
+	end
+	if self.data.cover_cache_enabled == nil then
+		self.data.cover_cache_enabled = true
+	end
+	if self.data.cover_cache_max_mb == nil then
+		self.data.cover_cache_max_mb = Constants.COVER_CACHE.DEFAULT_MAX_MB
+	end
+	if self.data.cover_cache_ttl_minutes == nil then
+		self.data.cover_cache_ttl_minutes = Constants.COVER_CACHE.DEFAULT_TTL_MINUTES
+	end
 
 	-- Font settings
 	for key, default_value in pairs(Constants.DEFAULT_FONT_SETTINGS) do

--- a/config/settings_menu.lua
+++ b/config/settings_menu.lua
@@ -18,6 +18,66 @@ function SettingsMenu.create(plugin)
 			text = _("Settings"),
 			sub_item_table = {
 				{
+					text = _("Cover Settings"),
+					sub_item_table = {
+						{
+							text = _("Prefer Large Covers"),
+							checked_func = function()
+								return plugin:getSetting("prefer_large_covers") == true
+							end,
+							callback = function()
+								local current = plugin:getSetting("prefer_large_covers") == true
+								plugin:saveSetting("prefer_large_covers", not current)
+								UIManager:show(InfoMessage:new {
+									text = not current and
+										_("High-quality cover source enabled.\n\nChanges apply on next catalog browse.") or
+										_("Fast thumbnail cover source enabled.\n\nChanges apply on next catalog browse."),
+									timeout = 2,
+								})
+							end,
+						},
+						{
+							text = _("Enable Cover Cache"),
+							checked_func = function()
+								return plugin:getSetting("cover_cache_enabled") ~= false
+							end,
+							callback = function()
+								local current = plugin:getSetting("cover_cache_enabled") ~= false
+								plugin:saveSetting("cover_cache_enabled", not current)
+								UIManager:show(InfoMessage:new {
+									text = not current and
+										_("Cover cache enabled.\n\nPreviously downloaded covers can be reused.") or
+										_("Cover cache disabled.\n\nCovers will be fetched from the server each time."),
+									timeout = 2,
+								})
+							end,
+						},
+						{
+							text = _("Advanced"),
+							sub_item_table = {
+								{
+									text = _("Cache Size (MB)"),
+									callback = function()
+										plugin:showCoverCacheSizeDialog()
+									end,
+								},
+								{
+									text = _("Cache TTL (minutes)"),
+									callback = function()
+										plugin:showCoverCacheTTLDialog()
+									end,
+								},
+								{
+									text = _("Clear Cover Cache"),
+									callback = function()
+										plugin:clearCoverCache()
+									end,
+								},
+							},
+						},
+					},
+				},
+				{
 					text = _("Display Mode"),
 					sub_item_table = {
 						{

--- a/core/browser_context.lua
+++ b/core/browser_context.lua
@@ -29,6 +29,7 @@ function BrowserContext.fromBrowser(browser)
 
 		-- Runtime state
 		sync = browser.sync,
+		prefer_large_covers = browser.settings and browser.settings.prefer_large_covers == true,
 
 		-- Authentication
 		username = browser.root_catalog_username,

--- a/core/navigation_handler.lua
+++ b/core/navigation_handler.lua
@@ -183,8 +183,11 @@ function NavigationHandler.genItemTableFromCatalog(catalog, item_url, browser_co
 				debug_callback("Book entry with cover:", title)
 			end
 
-			-- Prefer thumbnail over full image for performance
-			if item.thumbnail then
+			-- Prefer larger images only when explicitly enabled.
+			if browser_context.prefer_large_covers and item.image then
+				item.cover_url = item.image
+				item.lazy_load_cover = true
+			elseif item.thumbnail then
 				item.cover_url = item.thumbnail
 				item.lazy_load_cover = true
 			elseif item.image then

--- a/main.lua
+++ b/main.lua
@@ -280,6 +280,18 @@ function OPDS:showGridBorderColorMenu()
     SettingsDialogs.showGridBorderColorMenu(self)
 end
 
+function OPDS:showCoverCacheSizeDialog()
+    SettingsDialogs.showCoverCacheSizeDialog(self)
+end
+
+function OPDS:showCoverCacheTTLDialog()
+    SettingsDialogs.showCoverCacheTTLDialog(self)
+end
+
+function OPDS:clearCoverCache()
+    SettingsDialogs.clearCoverCache()
+end
+
 function OPDS:onShowOPDSCatalog()
     self.opds_browser = self:_createBrowserInstance()
     UIManager:show(self.opds_browser)

--- a/models/constants.lua
+++ b/models/constants.lua
@@ -72,6 +72,16 @@ local Constants = {
 	-- Cache Configuration
 	CACHE_SLOTS = 20,
 
+	-- Cover Cache Configuration
+	COVER_CACHE = {
+		DEFAULT_MAX_MB = 64,
+		DEFAULT_TTL_MINUTES = 720, -- 12 hours
+		MIN_MAX_MB = 8,
+		MAX_MAX_MB = 1024,
+		MIN_TTL_MINUTES = 5,
+		MAX_TTL_MINUTES = 10080, -- 7 days
+	},
+
 	-- UI Icons
 	ICONS = {
 		MENU = "appbar.menu",

--- a/services/cover_cache.lua
+++ b/services/cover_cache.lua
@@ -1,0 +1,163 @@
+local DataStorage = require("datastorage")
+local lfs = require("libs/libkoreader-lfs")
+local bit = require("bit")
+
+local CoverCache = {}
+
+local CACHE_DIR = DataStorage:getDataDir() .. "/cache/opds_plus/covers"
+
+local function ensureDir(path)
+	if lfs.attributes(path, "mode") == "directory" then
+		return true
+	end
+
+	local current = ""
+	for part in path:gmatch("[^/]+") do
+		current = current == "" and ("/" .. part) or (current .. "/" .. part)
+		if lfs.attributes(current, "mode") ~= "directory" then
+			local ok = lfs.mkdir(current)
+			if not ok then
+				return false
+			end
+		end
+	end
+	return true
+end
+
+local function hashUrl(url)
+	local h1 = 5381
+	local h2 = 2166136261
+
+	for i = 1, #url do
+		local b = string.byte(url, i)
+		h1 = bit.tobit(bit.bxor((h1 * 33), b))
+		h2 = bit.tobit((h2 * 16777619) + b)
+	end
+
+	return bit.tohex(h1) .. bit.tohex(h2)
+end
+
+local function cachePath(url)
+	return CACHE_DIR .. "/" .. hashUrl(url) .. ".img"
+end
+
+local function readFile(path)
+	local f = io.open(path, "rb")
+	if not f then
+		return nil
+	end
+	local data = f:read("*a")
+	f:close()
+	return data
+end
+
+local function writeFile(path, content)
+	local f = io.open(path, "wb")
+	if not f then
+		return false
+	end
+	f:write(content)
+	f:close()
+	return true
+end
+
+local function listCacheFiles()
+	local files = {}
+	local total = 0
+
+	if lfs.attributes(CACHE_DIR, "mode") ~= "directory" then
+		return files, total
+	end
+
+	for name in lfs.dir(CACHE_DIR) do
+		if name ~= "." and name ~= ".." and name:sub(-4) == ".img" then
+			local path = CACHE_DIR .. "/" .. name
+			local attr = lfs.attributes(path)
+			if attr and attr.mode == "file" then
+				local size = attr.size or 0
+				table.insert(files, {
+					path = path,
+					size = size,
+					mtime = attr.modification or 0,
+				})
+				total = total + size
+			end
+		end
+	end
+
+	return files, total
+end
+
+local function pruneToMaxBytes(max_bytes)
+	if not max_bytes or max_bytes <= 0 then
+		return
+	end
+
+	local files, total = listCacheFiles()
+	if total <= max_bytes then
+		return
+	end
+
+	table.sort(files, function(a, b)
+		return a.mtime < b.mtime
+	end)
+
+	for _, file in ipairs(files) do
+		if total <= max_bytes then
+			break
+		end
+
+		os.remove(file.path)
+		total = total - file.size
+	end
+end
+
+function CoverCache.get(url, ttl_seconds)
+	local path = cachePath(url)
+	local attr = lfs.attributes(path)
+	if not attr or attr.mode ~= "file" then
+		return nil
+	end
+
+	local content = readFile(path)
+	if not content or content == "" then
+		return nil
+	end
+
+	local age = os.time() - (attr.modification or 0)
+	return {
+		content = content,
+		stale = ttl_seconds and age > ttl_seconds or false,
+		age_seconds = age,
+	}
+end
+
+function CoverCache.put(url, content, max_bytes)
+	if not content or content == "" then
+		return false
+	end
+
+	if not ensureDir(CACHE_DIR) then
+		return false
+	end
+
+	local ok = writeFile(cachePath(url), content)
+	if ok and max_bytes and max_bytes > 0 then
+		pruneToMaxBytes(max_bytes)
+	end
+	return ok
+end
+
+function CoverCache.clear()
+	if lfs.attributes(CACHE_DIR, "mode") ~= "directory" then
+		return
+	end
+
+	for name in lfs.dir(CACHE_DIR) do
+		if name ~= "." and name ~= ".." and name:sub(-4) == ".img" then
+			os.remove(CACHE_DIR .. "/" .. name)
+		end
+	end
+end
+
+return CoverCache

--- a/services/cover_loader.lua
+++ b/services/cover_loader.lua
@@ -97,6 +97,14 @@ function CoverLoader.loadVisibleCovers(menu, debug_log)
 	-- Get credentials from the menu
 	local username = menu.root_catalog_username
 	local password = menu.root_catalog_password
+	local cache_enabled = true
+	local cache_max_mb = nil
+	local cache_ttl_minutes = nil
+	if menu.settings and menu.settings.cover_cache_enabled ~= nil then
+		cache_enabled = menu.settings.cover_cache_enabled ~= false
+		cache_max_mb = menu.settings.cover_cache_max_mb
+		cache_ttl_minutes = menu.settings.cover_cache_ttl_minutes
+	end
 
 	-- Create render callback
 	local render_callback = CoverLoader.createRenderCallback(
@@ -106,7 +114,15 @@ function CoverLoader.loadVisibleCovers(menu, debug_log)
 	)
 
 	-- Load covers asynchronously
-	local _, halt = ImageLoader:loadImages(urls, render_callback, username, password)
+	local _, halt = ImageLoader:loadImages(
+		urls,
+		render_callback,
+		username,
+		password,
+		cache_enabled,
+		cache_max_mb,
+		cache_ttl_minutes
+	)
 
 	-- Clear the pending items
 	menu._items_to_update = {}

--- a/services/image_loader.lua
+++ b/services/image_loader.lua
@@ -1,8 +1,8 @@
 local HttpClient = require("services.http_client")
 local UIManager = require("ui/uimanager")
-local Trapper = require("ui/trapper")
 local Constants = require("models.constants")
 local Debug = require("utils.debug")
+local CoverCache = require("services.cover_cache")
 
 local ImageLoader = {}
 
@@ -25,38 +25,82 @@ function Batch:loadImages(urls)
     end
 
     self.loading = true
-    local url_queue = { table.unpack(urls) }
     local stop_loading = false
+    local pending_urls = { table.unpack(urls) }
+    local ttl_seconds = (self.cache_ttl_minutes or Constants.COVER_CACHE.DEFAULT_TTL_MINUTES) * 60
+    local max_bytes = (self.cache_max_mb or Constants.COVER_CACHE.DEFAULT_MAX_MB) * 1024 * 1024
 
     local run_image
     run_image = function()
-        Trapper:wrap(function()
-            if stop_loading then return end
+        if stop_loading then
+            self.loading = false
+            return
+        end
 
-            local url = table.remove(url_queue, 1)
+        local url = table.remove(pending_urls, 1)
+        if not url then
+            self.loading = false
+            return
+        end
 
-            Debug.log("ImageLoader:", "Fetching cover with auth:", self.username and "yes" or "no")
+        local stale_content = nil
+        if self.cover_cache_enabled ~= false then
+            local cached = CoverCache.get(url, ttl_seconds)
+            if cached and not cached.stale then
+                Debug.log("ImageLoader:", "Cover cache hit:", url)
+                if self.callback then
+                    self.callback(url, cached.content)
+                end
 
-            local completed, success, content = Trapper:dismissableRunInSubprocess(function()
-                return HttpClient.getUrlContent(url,
-                    Constants.TIMEOUTS.IMAGE_LOAD,
-                    Constants.TIMEOUTS.IMAGE_MAX_TIME,
-                    self.username, self.password)
-            end)
+                if #pending_urls > 0 then
+                    UIManager:scheduleIn(Constants.UI_TIMING.IMAGE_BATCH_DELAY, run_image)
+                else
+                    self.loading = false
+                end
+                return
+            end
 
-            if completed and success then
+            Debug.log("ImageLoader:", "Cover cache miss:", url)
+            if cached and cached.content then
+                stale_content = cached.content
+            end
+        end
+
+        Debug.log("ImageLoader:", "Fetching cover with auth:", self.username and "yes" or "no")
+
+        local success, content = HttpClient.getUrlContent(
+            url,
+            Constants.TIMEOUTS.IMAGE_LOAD,
+            Constants.TIMEOUTS.IMAGE_MAX_TIME,
+            self.username,
+            self.password
+        )
+
+        if stop_loading then
+            self.loading = false
+            return
+        end
+
+        if success then
+            if self.callback then
                 self.callback(url, content)
-            elseif completed and not success then
-                -- Always log errors
-                Debug.error("ImageLoader:", "Failed to download cover:", content or "unknown error")
             end
 
-            if #url_queue > 0 then
-                UIManager:scheduleIn(Constants.UI_TIMING.IMAGE_BATCH_DELAY, run_image)
-            else
-                self.loading = false
+            if self.cover_cache_enabled ~= false then
+                CoverCache.put(url, content, max_bytes)
             end
-        end)
+        else
+            Debug.error("ImageLoader:", "Failed to download cover:", content or "unknown error")
+            if stale_content and self.callback then
+                self.callback(url, stale_content)
+            end
+        end
+
+        if #pending_urls > 0 then
+            UIManager:scheduleIn(Constants.UI_TIMING.IMAGE_BATCH_DELAY, run_image)
+        else
+            self.loading = false
+        end
     end
 
     if #urls == 0 then
@@ -67,6 +111,8 @@ function Batch:loadImages(urls)
 
     local halt = function()
         stop_loading = true
+        self.loading = false
+        self.callback = nil
         UIManager:unschedule(run_image)
     end
 
@@ -78,15 +124,26 @@ end
 -- @param callback function Callback(url, content) called for each loaded image
 -- @param username string|nil HTTP auth username
 -- @param password string|nil HTTP auth password
+-- @param cover_cache_enabled boolean|nil Whether to use in-memory cover cache (default: true)
+-- @param cache_max_mb number|nil Maximum cache size in MB
+-- @param cache_ttl_minutes number|nil Cache TTL in minutes
 -- @return table, function Batch instance and halt function
-function ImageLoader:loadImages(urls, callback, username, password)
+function ImageLoader:loadImages(urls, callback, username, password, cover_cache_enabled, cache_max_mb, cache_ttl_minutes)
     local batch = Batch:new {
         username = username,
         password = password,
+        cover_cache_enabled = cover_cache_enabled ~= false,
+        cache_max_mb = cache_max_mb,
+        cache_ttl_minutes = cache_ttl_minutes,
     }
     batch.callback = callback
     local halt = batch:loadImages(urls)
     return batch, halt
+end
+
+--- Clear disk cover cache.
+function ImageLoader.clearCache()
+    CoverCache.clear()
 end
 
 return ImageLoader

--- a/ui/dialogs/book_info_dialog.lua
+++ b/ui/dialogs/book_info_dialog.lua
@@ -298,7 +298,10 @@ function BookInfoDialog.build(browser, item)
 					updateCoverWidget(content)
 				end,
 				browser.root_catalog_username,
-				browser.root_catalog_password
+				browser.root_catalog_password,
+				browser.settings and browser.settings.cover_cache_enabled ~= false,
+				browser.settings and browser.settings.cover_cache_max_mb,
+				browser.settings and browser.settings.cover_cache_ttl_minutes
 			)
 		end
 	end

--- a/ui/dialogs/settings_dialogs.lua
+++ b/ui/dialogs/settings_dialogs.lua
@@ -6,6 +6,7 @@ local InfoMessage = require("ui/widget/infomessage")
 local SpinWidget = require("ui/widget/spinwidget")
 local UIManager = require("ui/uimanager")
 local Constants = require("models.constants")
+local ImageLoader = require("services.image_loader")
 local _ = require("gettext")
 local T = require("ffi/util").template
 
@@ -395,6 +396,71 @@ function SettingsDialogs.showGridBorderColorMenu(plugin)
 
 	plugin.grid_border_color_dialog = builder:build()
 	UIManager:show(plugin.grid_border_color_dialog)
+end
+
+--- Show cover cache size spinner (MB)
+-- @param plugin table Plugin instance
+function SettingsDialogs.showCoverCacheSizeDialog(plugin)
+	local current_mb = plugin:getSetting("cover_cache_max_mb") or Constants.COVER_CACHE.DEFAULT_MAX_MB
+
+	local spin_widget = SpinWidget:new {
+		title_text = _("Cover Cache Size"),
+		info_text = _("Set the maximum disk space used for cached cover images.\n\nLarger values improve offline reuse and reduce refetching after browsing."),
+		value = current_mb,
+		value_min = Constants.COVER_CACHE.MIN_MAX_MB,
+		value_max = Constants.COVER_CACHE.MAX_MAX_MB,
+		value_step = 8,
+		value_hold_step = 32,
+		unit = "MB",
+		ok_text = _("Apply"),
+		default_value = Constants.COVER_CACHE.DEFAULT_MAX_MB,
+		callback = function(spin)
+			plugin:saveSetting("cover_cache_max_mb", spin.value)
+			UIManager:show(InfoMessage:new {
+				text = T(_("Cover cache size set to %1 MB."), spin.value),
+				timeout = 2,
+			})
+		end,
+	}
+
+	UIManager:show(spin_widget)
+end
+
+--- Show cover cache TTL spinner (minutes)
+-- @param plugin table Plugin instance
+function SettingsDialogs.showCoverCacheTTLDialog(plugin)
+	local current_ttl = plugin:getSetting("cover_cache_ttl_minutes") or Constants.COVER_CACHE.DEFAULT_TTL_MINUTES
+
+	local spin_widget = SpinWidget:new {
+		title_text = _("Cover Cache TTL"),
+		info_text = _("Set how long cached covers remain fresh before revalidation by refetching.\n\nShorter TTL picks up changed covers sooner. Longer TTL reduces network requests."),
+		value = current_ttl,
+		value_min = Constants.COVER_CACHE.MIN_TTL_MINUTES,
+		value_max = Constants.COVER_CACHE.MAX_TTL_MINUTES,
+		value_step = 5,
+		value_hold_step = 60,
+		unit = _("min"),
+		ok_text = _("Apply"),
+		default_value = Constants.COVER_CACHE.DEFAULT_TTL_MINUTES,
+		callback = function(spin)
+			plugin:saveSetting("cover_cache_ttl_minutes", spin.value)
+			UIManager:show(InfoMessage:new {
+				text = T(_("Cover cache TTL set to %1 minutes."), spin.value),
+				timeout = 2,
+			})
+		end,
+	}
+
+	UIManager:show(spin_widget)
+end
+
+--- Clear disk cover cache
+function SettingsDialogs.clearCoverCache()
+	ImageLoader.clearCache()
+	UIManager:show(InfoMessage:new {
+		text = _("Cover cache cleared."),
+		timeout = 2,
+	})
 end
 
 return SettingsDialogs


### PR DESCRIPTION
## Summary
This PR implements a combined approach for issue #56 that improves cover quality while staying safe on KOReader/Kindle process and memory constraints.

## Why this over PR #68
PR #68 introduces the large-cover preference but reads settings in the hot parsing path. This PR keeps the same user outcome but propagates settings through runtime context, avoiding per-entry settings file reads.

## Changes
- Add `Prefer Large Covers` setting and wire it through browser context/parsing.
- Add disk-backed cover cache service:
  - configurable max size (MB)
  - configurable TTL (minutes)
  - explicit cache clear action
- Add advanced cover-cache settings UI under Cover Settings.
- Replace cover image loader subprocess usage with lifecycle-safe scheduled fetching to avoid persistent subprocess collection loops and lingering processes.
- Keep stale-cache fallback for failed fetches.
- Add explicit cache hit/miss logging for verification.

## Files touched
- `config/settings.lua`
- `config/settings_menu.lua`
- `core/browser_context.lua`
- `core/navigation_handler.lua`
- `main.lua`
- `models/constants.lua`
- `services/cover_loader.lua`
- `services/image_loader.lua`
- `services/cover_cache.lua` (new)
- `ui/dialogs/book_info_dialog.lua`
- `ui/dialogs/settings_dialogs.lua`

## User-verified behavior
- Larger covers option works.
- Disk cache behavior and controls are functional.
- Subprocess loop issue investigated and addressed by removing cover-loader subprocess path.

Closes #56