### PR TITLE
Fix Komga/streaming OPDS book dialog crash

### DIFF
--- a/ui/dialogs/book_info_dialog.lua
+++ b/ui/dialogs/book_info_dialog.lua
@@ -44,7 +44,7 @@ local BookInfoDialog = {}
 -- @return string Formatted list of available formats
 local function formatAvailableFormats(acquisitions, DownloadManager)
 	local formats = {}
-	for _, acquisition in ipairs(acquisitions) do
+	for i, acquisition in ipairs(acquisitions) do
 		if acquisition.count then
 			-- PSE streaming
 			table.insert(formats, _("Stream") .. " (" .. acquisition.count .. " " .. _("pages") .. ")")


### PR DESCRIPTION
## Summary
Fix a crash when opening a book entry from OPDS catalogs that include streaming links (e.g., Komga).

## Root cause
In `formatAvailableFormats`, the loop index used `_`, which shadowed the gettext function `_()`. When handling streaming acquisitions (`acquisition.count`), the code called `_('Stream')`, but `_` had become a number (loop index), causing a runtime error.

## Fix
- Rename the loop index variable from `_` to `i` to avoid shadowing gettext.

## Validation
- Reproduced stack trace path and confirmed the crash point.
- Applied minimal one-line fix in `ui/dialogs/book_info_dialog.lua`.
- Verified no syntax/problems reported for the edited file.

Fixes #75