### PR TITLE
Add Stream from page option to book info dialog

### DIFF
--- a/ui/dialogs/book_info_dialog.lua
+++ b/ui/dialogs/book_info_dialog.lua
@@ -44,7 +44,7 @@ local BookInfoDialog = {}
 -- @return string Formatted list of available formats
 local function formatAvailableFormats(acquisitions, DownloadManager)
 	local formats = {}
-	for _, acquisition in ipairs(acquisitions) do
+	for i, acquisition in ipairs(acquisitions) do
 		if acquisition.count then
 			-- PSE streaming
 			table.insert(formats, _("Stream") .. " (" .. acquisition.count .. " " .. _("pages") .. ")")

--- a/ui/dialogs/book_info_dialog.lua
+++ b/ui/dialogs/book_info_dialog.lua
@@ -408,10 +408,19 @@ function BookInfoDialog.build(browser, item)
 						browser.root_catalog_username, browser.root_catalog_password)
 				end,
 			},
+			{
+				text = _("Stream from page") .. " " .. Constants.ICONS.STREAM_NEXT,
+				callback = function()
+					UIManager:close(browser.book_info_dialog)
+					OPDSPSE:streamPages(pse_acquisition.href, pse_acquisition.count, true,
+						browser.root_catalog_username, browser.root_catalog_password)
+				end,
+			},
 		}
 
 		if pse_acquisition.last_read then
-			table.insert(stream_row, {
+			table.insert(buttons_table, stream_row)
+			table.insert(buttons_table, {
 				text = Constants.ICONS.STREAM_RESUME .. " " .. _("Resume") .. " (" .. pse_acquisition.last_read .. ")",
 				callback = function()
 					UIManager:close(browser.book_info_dialog)
@@ -420,9 +429,9 @@ function BookInfoDialog.build(browser, item)
 						pse_acquisition.last_read)
 				end,
 			})
+		else
+			table.insert(buttons_table, stream_row)
 		end
-
-		table.insert(buttons_table, stream_row)
 	end
 
 	-- Row 2: Download and Queue buttons


### PR DESCRIPTION
Summary:
- Adds missing "Stream from page" action in OPDSPSE flow.
- Keeps "Resume" behavior unchanged.

Why:
- Restores parity with upstream OPDS plugin behavior.

Testing:
- Open a Komga OPDS book entry.
- Verify buttons include Stream and Stream from page.
- Verify Stream from page prompts for page and starts stream.