### PR TITLE
Adds skip functions to sync

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,30 +1,37 @@
 ---
 name: Bug report
-about: Report a problem with OPDS Plus
+about: Report a problem with OPDS++
 labels: bug
 ---
 
 ### Describe the bug
+
 A clear and concise description of what the bug is.
 
 ### To Reproduce
+
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Tap on '...'
 3. Scroll down to '...'
 4. See error
 
 ### Expected behavior
+
 A clear and concise description of what you expected to happen.
 
 ### Screenshots / Logs
+
 If possible, add screenshots or relevant lines from `crash.log`.
 
 ### Device information
+
 - Device model (e.g. Kobo Clara HD, Kindle Paperwhite 3, Android phone, etc.):
 - Screen resolution (if known):
 - KOReader version (from About screen):
-- OPDS Plus version (from plugin metadata or release tag):
+- OPDS++ version (from plugin metadata or release tag):
 
 ### Additional context
+
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,25 @@
 ---
 name: Feature request
-about: Suggest an idea or improvement for OPDS Plus
+about: Suggest an idea or improvement for OPDS++
 labels: enhancement
 ---
 
 ### Is your feature request related to a problem?
+
 A clear and concise description of what the problem is.
 
 ### Describe the solution you'd like
+
 A clear and concise description of what you want to happen.
 
 ### Describe alternatives you've considered
+
 A clear and concise description of any alternative solutions or features you've considered.
 
 ### Screenshots / Mockups
+
 If applicable, add screenshots or sketches to help explain your idea.
 
 ### Additional context
+
 Add any other context or comments here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
-# OPDS Plus Pull Request
+# OPDS++ Pull Request
 
-Thanks for contributing to OPDS Plus!
+Thanks for contributing to OPDS++!
 
 ## Summary
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## [1.2.0] - 2026-03-19
 
 ### Added
+
 - **Book Info Dialog**: Added a dedicated dialog with at-a-glance book metadata and improved cover handling.
 - **Direct Sync Gesture Actions**: Added action-oriented gesture events for faster sync and navigation workflows.
 - **Improved Cover Pipeline**: Added higher-quality cover loading with disk-backed cache and lifecycle-safe image handling.
@@ -19,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
   - Supports direct invocation from KOReader gesture/action mapping
 
 ### Changed
+
 - **Debug Architecture Refactor**:
   - Standardized debug logging through shared utility usage.
   - Extended state manager integration across UI menu components.
@@ -27,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
   - Updated GitHub Actions dependencies for checkout and artifact upload/download workflows.
 
 ### Fixed
+
 - **Gesture Registration**: Fixed gesture registration failures (Issue #58).
 - **Duplicate PDF Entries**: Prevented duplicate PDF files from being shown in results (Issue #57).
 - **Book Info Dialog Stability**:
@@ -35,16 +38,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
   - Removed invalid imports and corrected build wiring.
 
 ### Notes
+
 - This release includes merged community and maintenance pull requests together with issue-resolution fixes.
 - Packaging layout improvements from prior releases are retained and compatible with the current codebase structure.
-- New settings are available under **OPDS Plus Catalog → Settings → Cover Settings**.
+- New settings are available under **OPDS++ Catalog → Settings → Cover Settings**.
 - Sync actions can be used from catalog long-press workflows or mapped through KOReader dispatcher actions.
 
 ## [1.1.0] - 2025-01-18
 
 ### Added
+
 - **Debug Mode Toggle**: Added developer setting to enable/disable verbose logging for troubleshooting
-- **Version Display**: Plugin version now shown in settings menu ("About OPDS Plus v1.1.0")
+- **Version Display**: Plugin version now shown in settings menu ("About OPDS++ v1.1.0")
 - **Smart Text Truncation**: Titles and authors now display with ellipsis (…) when truncated
   - UTF-8 safe truncation for international characters
   - Word-aware truncation attempts to break at word boundaries
@@ -56,6 +61,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
   - Adaptive sizing works across all device screen sizes
 
 ### Changed
+
 - **Improved List View Sizing**:
   - Preset sizes now target specific items per page (3, 4, 6, or 8 items)
   - Dynamically calculates optimal cover height to fill available space
@@ -72,6 +78,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
   - Significantly reduced log spam in production use
 
 ### Fixed
+
 - **Release Package Structure**: GitHub Actions workflow now creates clean zip without nested directories
 - **Template String Formatting**: Fixed `%%` appearing in confirmation dialogs (now displays as single `%`)
 - **Loop Variable Conflicts**:
@@ -82,18 +89,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - **Font Method Calls**: Corrected text width measurement to use proper KOReader API (`RenderText:sizeUtf8Text()`)
 
 ### Technical Improvements
+
 - Conditional debug logging via `_debugLog()` method in all core modules
 - Improved error handling and logging consistency
 - Better separation of production vs. development logging
 - Enhanced code maintainability with cleaner function signatures
 
 ### Performance
+
 - Reduced UI lag from excessive logging in production
 - Optimized text truncation algorithm using binary search
 - Improved rendering performance with better whitespace calculations
 
 ### Notes
-- Debug mode can be toggled in: **OPDS Plus Catalog → Settings → Developer → Debug Mode**
+
+- Debug mode can be toggled in: **OPDS++ Catalog → Settings → Developer → Debug Mode**
 - Changes to view settings (cover sizes, grid layouts) apply when next browsing a catalog
 - Compatible with all KOReader-supported devices and screen sizes
 - Tested on e-readers, tablets, and desktop displays
@@ -101,8 +111,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ---
 
 ## [1.0.0] - 2025-11-17
+
 ### Added
-- Initial public release of OPDS Plus plugin.
+
+- Initial public release of OPDS++ plugin.
 - Extended OPDS browsing with cover display support (list & grid view).
 - Grid view with customizable columns, border styles, thickness, and color.
 - Font customization for titles and information text (family, size, weight, color).
@@ -111,6 +123,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Persistent settings storage and retrieval.
 
 ### Notes
+
 - Derivative of KOReader's built-in OPDS plugin with major UI/UX enhancements.
 - Licensed under AGPLv3 consistent with KOReader.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,34 +1,34 @@
-# Contributing to OPDS Plus
+# Contributing to OPDS++
 
-First off, thank you for considering contributing to OPDS Plus! It's people like you that make OPDS Plus such a great tool for the KOReader community.
+First off, thank you for considering contributing to OPDS++! It's people like you that make OPDS++ such a great tool for the KOReader community.
 
 ## Table of Contents
 
-- [Contributing to OPDS Plus](#contributing-to-opds-plus)
-	- [Table of Contents](#table-of-contents)
-	- [Code of Conduct](#code-of-conduct)
-	- [How Can I Contribute?](#how-can-i-contribute)
-		- [Reporting Bugs](#reporting-bugs)
-		- [Suggesting Enhancements](#suggesting-enhancements)
-		- [Your First Code Contribution](#your-first-code-contribution)
-		- [Pull Requests](#pull-requests)
-			- [Pull Request Process](#pull-request-process)
-	- [Style Guidelines](#style-guidelines)
-		- [Lua Code Style](#lua-code-style)
-		- [Git Commit Messages](#git-commit-messages)
-		- [Documentation Style](#documentation-style)
-	- [Development Setup](#development-setup)
-		- [Prerequisites](#prerequisites)
-		- [Setting Up Development Environment](#setting-up-development-environment)
-		- [File Structure Understanding](#file-structure-understanding)
-		- [Key Components](#key-components)
-	- [Testing](#testing)
-		- [Manual Testing Checklist](#manual-testing-checklist)
-		- [Test on Multiple Catalogs](#test-on-multiple-catalogs)
-		- [Device Testing](#device-testing)
-		- [Debug Mode Testing](#debug-mode-testing)
-	- [Questions?](#questions)
-	- [Recognition](#recognition)
+- [Contributing to OPDS++](#contributing-to-opds-plus)
+  - [Table of Contents](#table-of-contents)
+  - [Code of Conduct](#code-of-conduct)
+  - [How Can I Contribute?](#how-can-i-contribute)
+    - [Reporting Bugs](#reporting-bugs)
+    - [Suggesting Enhancements](#suggesting-enhancements)
+    - [Your First Code Contribution](#your-first-code-contribution)
+    - [Pull Requests](#pull-requests)
+      - [Pull Request Process](#pull-request-process)
+  - [Style Guidelines](#style-guidelines)
+    - [Lua Code Style](#lua-code-style)
+    - [Git Commit Messages](#git-commit-messages)
+    - [Documentation Style](#documentation-style)
+  - [Development Setup](#development-setup)
+    - [Prerequisites](#prerequisites)
+    - [Setting Up Development Environment](#setting-up-development-environment)
+    - [File Structure Understanding](#file-structure-understanding)
+    - [Key Components](#key-components)
+  - [Testing](#testing)
+    - [Manual Testing Checklist](#manual-testing-checklist)
+    - [Test on Multiple Catalogs](#test-on-multiple-catalogs)
+    - [Device Testing](#device-testing)
+    - [Debug Mode Testing](#debug-mode-testing)
+  - [Questions?](#questions)
+  - [Recognition](#recognition)
 
 ## Code of Conduct
 
@@ -47,7 +47,7 @@ Before creating bug reports, please check the existing issues to avoid duplicate
 - **Expected behavior** and what actually happened
 - **Screenshots** if applicable
 - **KOReader version** and device information
-- **OPDS Plus version** (found in Settings → About)
+- **OPDS++ version** (found in Settings → About)
 - **OPDS catalog** you were browsing when the issue occurred
 - **Log files** if available (enable Debug Mode in Developer settings)
 
@@ -57,7 +57,7 @@ Enhancement suggestions are tracked as GitHub issues. When creating an enhanceme
 
 - **Use a clear, descriptive title**
 - **Provide a detailed description** of the suggested enhancement
-- **Explain why this enhancement would be useful** to most OPDS Plus users
+- **Explain why this enhancement would be useful** to most OPDS++ users
 - **List any similar features** in other applications if applicable
 - **Include mockups or examples** if you have them
 
@@ -132,6 +132,7 @@ return MyModule
 ```
 
 **Key conventions:**
+
 - 4 spaces for indentation
 - `snake_case` for variables and functions
 - `PascalCase` for class/module names
@@ -157,6 +158,7 @@ return MyModule
   - ✅ `:white_check_mark:` - Adding tests
 
 **Example:**
+
 ```
 ✨ Add custom border color option for grid view
 
@@ -189,17 +191,20 @@ Closes #42
 ### Setting Up Development Environment
 
 1. **Clone your fork:**
+
    ```bash
    git clone https://github.com/YOUR_USERNAME/opds_plus.koplugin.git
    cd opds_plus.koplugin
    ```
 
 2. **Create a development branch:**
+
    ```bash
    git checkout -b feature/my-new-feature
    ```
 
 3. **Link to KOReader plugins directory:**
+
    ```bash
    # Linux example
    ln -s $(pwd) ~/.config/koreader/plugins/opds_plus.koplugin
@@ -209,7 +214,7 @@ Closes #42
    ```
 
 4. **Enable Debug Mode:**
-   - In KOReader: OPDS Plus → Settings → Developer → Debug Mode
+   - In KOReader: OPDS++ → Settings → Developer → Debug Mode
    - This enables detailed logging for development
 
 5. **Make your changes** and test in KOReader
@@ -268,6 +273,7 @@ Before submitting a PR, test the following:
 ### Test on Multiple Catalogs
 
 Test with different OPDS catalogs:
+
 - Project Gutenberg (large catalog)
 - Standard Ebooks (high-quality covers)
 - Your local Calibre library (if available)
@@ -276,6 +282,7 @@ Test with different OPDS catalogs:
 ### Device Testing
 
 If possible, test on:
+
 - E-ink device (Kindle, Kobo)
 - Android device
 - Desktop (Linux/Windows/macOS)
@@ -290,6 +297,7 @@ If possible, test on:
 ## Questions?
 
 Feel free to:
+
 - Open an issue for discussion
 - Ask questions in pull requests
 - Reach out to the maintainer
@@ -297,10 +305,11 @@ Feel free to:
 ## Recognition
 
 Contributors will be recognized in:
+
 - Git commit history
 - Release notes
 - README credits (for significant contributions)
 
 ---
 
-Thank you for contributing to OPDS Plus! 📚✨
+Thank you for contributing to OPDS++! 📚✨

--- a/README.md
+++ b/README.md
@@ -193,11 +193,13 @@ Access settings from: **OPDS Plus Catalog → Settings**
 ### Sync Actions & Settings (New in 1.2.0)
 
 - **Direct Sync Actions**:
-  - Sync all catalogs
-  - Force sync all catalogs
+  - Sync all catalogs (verify dups) - synchronize new items, and choose how to handle files already on your device
+  - Sync all catalogs (skip dups) - synchronize items not already on your device
+  - Force sync all catalogs -  re-download all items
 - **Gesture Integration**:
   - Actions are registered in KOReader's dispatcher as:
-    - `OPDS Plus: Sync all catalogs`
+    - `OPDS Plus: Sync all catalogs (verify dups)`
+    - `OPDS Plus: Sync all catalogs (skip dups)`
     - `OPDS Plus: Force sync all catalogs`
   - These can be assigned in KOReader's gesture/action configuration.
 - **Catalog Sync Controls**:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![OPDS Plus Banner](.github/assets/hero_banner.png)
+![OPDS++ Banner](.github/assets/hero_banner.png)
 
 <div align="center">
 
@@ -9,15 +9,16 @@
 
 </div>
 
-# OPDS Plus - Enhanced OPDS Browser for KOReader
+# OPDS++ - Enhanced OPDS Browser for KOReader
 
 **Version:** 1.2.0
 
-**OPDS Plus** is a feature-rich enhancement of KOReader's built-in OPDS catalog browser, providing visual book cover displays, multiple viewing modes, and extensive customization options for browsing online book catalogs.
+**OPDS++** is a feature-rich enhancement of KOReader's built-in OPDS catalog browser, providing visual book cover displays, multiple viewing modes, and extensive customization options for browsing online book catalogs.
 
 ## ✨ Features
 
 ### 📚 Enhanced Catalog Browsing
+
 - **Visual Book Covers**: Browse catalogs with book cover images displayed alongside titles
 - **Dual View Modes**: Switch between List View and Grid View layouts
 - **Multiple Display Options**: Customize how books are presented
@@ -26,12 +27,14 @@
 - **Cover Quality + Cache**: Improved cover rendering pipeline with disk-backed caching
 
 ### 🖼️ List View
+
 - Book covers displayed alongside title and author information
 - Adjustable cover sizes with presets (Compact, Regular, Large, Extra Large)
 - Custom size option (5-25% of screen height)
 - Clean, readable layout optimized for e-readers
 
 ### 📊 Grid View
+
 - Display books in a grid layout for visual browsing
 - Flexible column options (2-4 columns)
 - Layout presets: Compact (4 cols), Balanced (3 cols), Spacious (2 cols)
@@ -42,6 +45,7 @@
 - Adjustable border thickness (1-5px) and color (Light Gray, Dark Gray, Black)
 
 ### 🎨 Customization Options
+
 - **Font Selection**: Choose from KOReader's built-in fonts or your custom fonts
 - **Independent Font Settings**: Separate customization for titles and details
   - Font family selection
@@ -52,6 +56,7 @@
 - **Persistent Settings**: All preferences are saved between sessions
 
 ### 📖 Default Catalogs Included
+
 - Project Gutenberg
 - Standard Ebooks
 - ManyBooks
@@ -64,12 +69,12 @@
 |                        **List View**                        |                        **Grid View**                        |
 | :---------------------------------------------------------: | :---------------------------------------------------------: |
 | ![List View with Covers](.github/screenshots/list_view.png) | ![Grid View with Covers](.github/screenshots/grid_view.png) |
-|          *Classic list view with cover thumbnails*          |            *Immersive grid layout for browsing*             |
+|          _Classic list view with cover thumbnails_          |            _Immersive grid layout for browsing_             |
 
 |                       **View Options**                        |                    **Customization**                    |
 | :-----------------------------------------------------------: | :-----------------------------------------------------: |
 | ![View Toggle Menu](.github/screenshots/view_toggle_menu.png) | ![Settings Menu](.github/screenshots/settings_menu.png) |
-|             *Switch views instantly via the menu*             |            *Extensive customization options*            |
+|             _Switch views instantly via the menu_             |            _Extensive customization options_            |
 
 ## 📥 Installation
 
@@ -82,23 +87,22 @@
 2. **Extract to KOReader plugins directory**:
 
    The location depends on your device:
-
    - **Kindle/Kobo/Android**: Extract to `/koreader/plugins/`
    - **Linux**: Extract to `~/.config/koreader/plugins/`
    - **Windows**: Extract to `%APPDATA%/koreader/plugins/`
    - **macOS**: Extract to `~/Library/Application Support/koreader/plugins/`
 
-  For complete platform-specific install/upgrade paths, see the KOReader wiki:
-  [KOReader Installation/Upgrading](https://github.com/koreader/koreader/wiki#installationupgrading)
+For complete platform-specific install/upgrade paths, see the KOReader wiki:
+[KOReader Installation/Upgrading](https://github.com/koreader/koreader/wiki#installationupgrading)
 
-   The archive should extract to create an `opds_plus.koplugin` directory containing all plugin files.
+The archive should extract to create an `opds_plus.koplugin` directory containing all plugin files.
 
 3. **Restart KOReader**: Close and reopen KOReader to load the plugin
 
 4. **Verify installation**:
    - Open KOReader's File Browser
    - Tap the menu icon (⋮ or ≡)
-   - You should see "OPDS Plus Catalog" in the menu
+   - You should see "OPDS++ Catalog" in the menu
 
 ### Method 2: Git Clone (For Developers)
 
@@ -113,6 +117,7 @@ git clone https://github.com/greywolf1499/opds_plus.koplugin.git
 ```
 
 ### Troubleshooting Installation
+
 - Ensure the directory is named exactly `opds_plus.koplugin`
 - Verify all `.lua` files are present in the plugin directory
 - Check that you have write permissions to the plugins directory
@@ -120,19 +125,21 @@ git clone https://github.com/greywolf1499/opds_plus.koplugin.git
 
 ## 🚀 Usage
 
-### Accessing OPDS Plus
+### Accessing OPDS++
 
 1. Open KOReader's **File Browser**
 2. Tap the **menu icon** (⋮ or ≡)
-3. Select **OPDS Plus Catalog**
+3. Select **OPDS++ Catalog**
 
 ### Browsing Catalogs
 
 #### First Time Setup
+
 - The plugin comes with several default catalogs pre-configured
 - Simply select a catalog to start browsing
 
 #### Browsing Books
+
 1. Select a catalog from the list
 2. Navigate through categories and books
 3. Tap a book to view details and download options
@@ -140,13 +147,15 @@ git clone https://github.com/greywolf1499/opds_plus.koplugin.git
 
 ### Customizing Settings
 
-Access settings from: **OPDS Plus Catalog → Settings**
+Access settings from: **OPDS++ Catalog → Settings**
 
 #### Display Mode
+
 - **List View**: Traditional list with covers on the left
 - **Grid View**: Visual grid layout with larger covers
 
 #### List View Settings
+
 - **Cover Size**: Choose from presets or set custom size
   - Compact (8%): More books per page
   - Regular (10%): Default balanced view
@@ -155,6 +164,7 @@ Access settings from: **OPDS Plus Catalog → Settings**
   - Custom: Fine-tune between 5-25%
 
 #### Cover Settings (New in 1.2.0)
+
 - **Prefer Large Covers**:
   - Enabled: prioritizes higher-quality cover sources when available.
   - Disabled: prefers faster thumbnail sources.
@@ -167,6 +177,7 @@ Access settings from: **OPDS Plus Catalog → Settings**
   - Clear Cover Cache
 
 #### Grid View Settings
+
 - **Grid Layout**:
   - Compact: 4 columns, more books visible
   - Balanced: 3 columns, good middle ground (default)
@@ -179,6 +190,7 @@ Access settings from: **OPDS Plus Catalog → Settings**
   - Color: Light Gray, Dark Gray, or Black
 
 #### Font & Text Settings
+
 - **Use Same Font for All**: Match title and detail fonts
 - **Title Settings**:
   - Font family
@@ -195,12 +207,12 @@ Access settings from: **OPDS Plus Catalog → Settings**
 - **Direct Sync Actions**:
   - Sync all catalogs (verify dups) - synchronize new items, and choose how to handle files already on your device
   - Sync all catalogs (skip dups) - synchronize items not already on your device
-  - Force sync all catalogs -  re-download all items
+  - Force sync all catalogs - re-download all items
 - **Gesture Integration**:
   - Actions are registered in KOReader's dispatcher as:
-    - `OPDS Plus: Sync all catalogs (verify dups)`
-    - `OPDS Plus: Sync all catalogs (skip dups)`
-    - `OPDS Plus: Force sync all catalogs`
+    - `OPDS++: Sync all catalogs (verify dups)`
+    - `OPDS++: Sync all catalogs (skip dups)`
+    - `OPDS++: Force sync all catalogs`
   - These can be assigned in KOReader's gesture/action configuration.
 - **Catalog Sync Controls**:
   - Per-catalog sync and force-sync via catalog long-press actions.
@@ -216,7 +228,7 @@ Access settings from: **OPDS Plus Catalog → Settings**
 
 ### Adding Your Own Catalogs
 
-1. Go to **OPDS Plus Catalog → Settings → Manage Catalogs**
+1. Go to **OPDS++ Catalog → Settings → Manage Catalogs**
 2. Select **Add Catalog**
 3. Enter:
    - Catalog name
@@ -226,10 +238,12 @@ Access settings from: **OPDS Plus Catalog → Settings**
 ## 🔧 Technical Details
 
 ### Requirements
+
 - KOReader v2025.10, minimum
 - Network connectivity for browsing online catalogs
 
 ### File Structure
+
 ```
 opds_plus.koplugin/
 ├── _meta.lua
@@ -277,9 +291,11 @@ opds_plus.koplugin/
 ```
 
 ### Settings Storage
+
 Settings are stored in: `<KOReader data dir>/settings/opdsplus.lua`
 
 This file contains:
+
 - Catalog list
 - Download history
 - Display preferences
@@ -299,6 +315,7 @@ Contributions are welcome! Here's how you can help:
    - Submit a PR with a clear description
 
 ### Development Guidelines
+
 - Follow KOReader's Lua coding conventions
 - Test on multiple screen sizes if possible
 - Ensure compatibility with existing OPDS catalogs
@@ -335,4 +352,4 @@ See [CHANGELOG.md](CHANGELOG.md) for detailed version history.
 
 ---
 
-**Enjoy enhanced OPDS browsing with OPDS Plus! 📚✨**
+**Enjoy enhanced OPDS browsing with OPDS++! 📚✨**

--- a/_meta.lua
+++ b/_meta.lua
@@ -1,8 +1,9 @@
 local _ = require("gettext")
 local V = require("opds_plus_version")
 return {
-    name = "opdsplus",
-    fullname = _("OPDS Plus"),
-    version = V.VERSION,
-    description = _([[OPDS catalog browser with book cover display support. Browse and download books from online catalogs with visual cover previews in list or grid view.]]),
+  name = "opdsplus",
+  fullname = _("OPDS++"),
+  version = V.VERSION,
+  description = _(
+  [[OPDS catalog browser with book cover display support. Browse and download books from online catalogs with visual cover previews in list or grid view.]]),
 }

--- a/config/settings.lua
+++ b/config/settings.lua
@@ -1,4 +1,4 @@
--- Settings management module for OPDS Plus
+-- Settings management module for OPDS++
 -- Handles persistence, defaults, and settings access
 
 local LuaSettings = require("luasettings")
@@ -11,16 +11,16 @@ local Settings = {}
 -- @param settings_file string Optional custom settings file path
 -- @return table Settings instance
 function Settings:new(settings_file)
-	local o = {}
-	setmetatable(o, self)
-	self.__index = self
+  local o = {}
+  setmetatable(o, self)
+  self.__index = self
 
-	o.settings_file = settings_file or DataStorage:getSettingsDir() .. "/opdsplus.lua"
-	o.storage = LuaSettings:open(o.settings_file)
-	o.data = o.storage.data
-	o.is_first_run = next(o.data) == nil
+  o.settings_file = settings_file or DataStorage:getSettingsDir() .. "/opdsplus.lua"
+  o.storage = LuaSettings:open(o.settings_file)
+  o.data = o.storage.data
+  o.is_first_run = next(o.data) == nil
 
-	return o
+  return o
 end
 
 --- Get a setting value with optional default
@@ -28,100 +28,100 @@ end
 -- @param default any Default value if not set
 -- @return any Setting value or default
 function Settings:get(key, default)
-	if self.data[key] ~= nil then
-		return self.data[key]
-	end
-	-- Check in font settings defaults
-	if Constants.DEFAULT_FONT_SETTINGS[key] ~= nil then
-		return Constants.DEFAULT_FONT_SETTINGS[key]
-	end
-	return default
+  if self.data[key] ~= nil then
+    return self.data[key]
+  end
+  -- Check in font settings defaults
+  if Constants.DEFAULT_FONT_SETTINGS[key] ~= nil then
+    return Constants.DEFAULT_FONT_SETTINGS[key]
+  end
+  return default
 end
 
 --- Set a setting value
 -- @param key string Setting key
 -- @param value any Value to set
 function Settings:set(key, value)
-	self.data[key] = value
+  self.data[key] = value
 end
 
 --- Save a specific setting and flush to disk
 -- @param key string Setting key
 -- @param value any Value to save
 function Settings:saveAndFlush(key, value)
-	self:set(key, value)
-	self:flush()
+  self:set(key, value)
+  self:flush()
 end
 
 --- Save settings to storage
 function Settings:save()
-	self.storage:saveSetting("settings", self.data)
+  self.storage:saveSetting("settings", self.data)
 end
 
 --- Flush settings to disk
 function Settings:flush()
-	self.storage:flush()
+  self.storage:flush()
 end
 
 --- Initialize all default settings
 function Settings:initializeDefaults()
-	-- Cover settings
-	if not self.data.cover_height_ratio then
-		self.data.cover_height_ratio = Constants.DEFAULT_COVER_HEIGHT_RATIO
-	end
-	if not self.data.cover_size_preset then
-		self.data.cover_size_preset = "Regular"
-	end
-	if self.data.prefer_large_covers == nil then
-		-- Migrate legacy raw setting key if present.
-		self.data.prefer_large_covers = self.storage:readSetting("large_cover") == true
-	end
-	if self.data.cover_cache_enabled == nil then
-		self.data.cover_cache_enabled = true
-	end
-	if self.data.cover_cache_max_mb == nil then
-		self.data.cover_cache_max_mb = Constants.COVER_CACHE.DEFAULT_MAX_MB
-	end
-	if self.data.cover_cache_ttl_minutes == nil then
-		self.data.cover_cache_ttl_minutes = Constants.COVER_CACHE.DEFAULT_TTL_MINUTES
-	end
+  -- Cover settings
+  if not self.data.cover_height_ratio then
+    self.data.cover_height_ratio = Constants.DEFAULT_COVER_HEIGHT_RATIO
+  end
+  if not self.data.cover_size_preset then
+    self.data.cover_size_preset = "Regular"
+  end
+  if self.data.prefer_large_covers == nil then
+    -- Migrate legacy raw setting key if present.
+    self.data.prefer_large_covers = self.storage:readSetting("large_cover") == true
+  end
+  if self.data.cover_cache_enabled == nil then
+    self.data.cover_cache_enabled = true
+  end
+  if self.data.cover_cache_max_mb == nil then
+    self.data.cover_cache_max_mb = Constants.COVER_CACHE.DEFAULT_MAX_MB
+  end
+  if self.data.cover_cache_ttl_minutes == nil then
+    self.data.cover_cache_ttl_minutes = Constants.COVER_CACHE.DEFAULT_TTL_MINUTES
+  end
 
-	-- Font settings
-	for key, default_value in pairs(Constants.DEFAULT_FONT_SETTINGS) do
-		if self.data[key] == nil then
-			self.data[key] = default_value
-		end
-	end
+  -- Font settings
+  for key, default_value in pairs(Constants.DEFAULT_FONT_SETTINGS) do
+    if self.data[key] == nil then
+      self.data[key] = default_value
+    end
+  end
 
-	-- Display mode settings
-	if not self.data.display_mode then
-		self.data.display_mode = "list" -- Default to list view
-	end
-	if not self.data.grid_columns then
-		self.data.grid_columns = Constants.DEFAULT_GRID_SETTINGS.columns
-	end
-	if not self.data.grid_cover_height_ratio then
-		self.data.grid_cover_height_ratio = Constants.DEFAULT_GRID_SETTINGS.cover_height_ratio
-	end
-	if not self.data.grid_size_preset then
-		self.data.grid_size_preset = Constants.DEFAULT_GRID_SETTINGS.size_preset
-	end
+  -- Display mode settings
+  if not self.data.display_mode then
+    self.data.display_mode = "list" -- Default to list view
+  end
+  if not self.data.grid_columns then
+    self.data.grid_columns = Constants.DEFAULT_GRID_SETTINGS.columns
+  end
+  if not self.data.grid_cover_height_ratio then
+    self.data.grid_cover_height_ratio = Constants.DEFAULT_GRID_SETTINGS.cover_height_ratio
+  end
+  if not self.data.grid_size_preset then
+    self.data.grid_size_preset = Constants.DEFAULT_GRID_SETTINGS.size_preset
+  end
 
-	-- Grid border settings
-	if not self.data.grid_border_style then
-		self.data.grid_border_style = Constants.DEFAULT_GRID_BORDER_SETTINGS.border_style
-	end
-	if not self.data.grid_border_size then
-		self.data.grid_border_size = Constants.DEFAULT_GRID_BORDER_SETTINGS.border_size
-	end
-	if not self.data.grid_border_color then
-		self.data.grid_border_color = Constants.DEFAULT_GRID_BORDER_SETTINGS.border_color
-	end
+  -- Grid border settings
+  if not self.data.grid_border_style then
+    self.data.grid_border_style = Constants.DEFAULT_GRID_BORDER_SETTINGS.border_style
+  end
+  if not self.data.grid_border_size then
+    self.data.grid_border_size = Constants.DEFAULT_GRID_BORDER_SETTINGS.border_size
+  end
+  if not self.data.grid_border_color then
+    self.data.grid_border_color = Constants.DEFAULT_GRID_BORDER_SETTINGS.border_color
+  end
 
-	-- Debug mode (default: false for production)
-	if self.data.debug_mode == nil then
-		self.data.debug_mode = false
-	end
+  -- Debug mode (default: false for production)
+  if self.data.debug_mode == nil then
+    self.data.debug_mode = false
+  end
 end
 
 --- Read a raw setting from storage
@@ -129,14 +129,14 @@ end
 -- @param default any Default value
 -- @return any Setting value
 function Settings:readSetting(key, default)
-	return self.storage:readSetting(key, default)
+  return self.storage:readSetting(key, default)
 end
 
 --- Save a raw setting to storage
 -- @param key string Setting key
 -- @param value any Value to save
 function Settings:saveSetting(key, value)
-	self.storage:saveSetting(key, value)
+  self.storage:saveSetting(key, value)
 end
 
 return Settings

--- a/config/settings_menu.lua
+++ b/config/settings_menu.lua
@@ -7,296 +7,296 @@ local Version = require("opds_plus_version")
 local SettingsMenu = {}
 
 function SettingsMenu.create(plugin)
-	return {
-		{
-			text = _("Browse Catalogs"),
-			callback = function()
-				plugin:onShowOPDSPlusCatalog()
-			end,
-		},
-		{
-			text = _("Settings"),
-			sub_item_table = {
-				{
-					text = _("Cover Settings"),
-					sub_item_table = {
-						{
-							text = _("Prefer Large Covers"),
-							checked_func = function()
-								return plugin:getSetting("prefer_large_covers") == true
-							end,
-							callback = function()
-								local current = plugin:getSetting("prefer_large_covers") == true
-								plugin:saveSetting("prefer_large_covers", not current)
-								UIManager:show(InfoMessage:new {
-									text = not current and
-										_("High-quality cover source enabled.\n\nChanges apply on next catalog browse.") or
-										_("Fast thumbnail cover source enabled.\n\nChanges apply on next catalog browse."),
-									timeout = 2,
-								})
-							end,
-						},
-						{
-							text = _("Enable Cover Cache"),
-							checked_func = function()
-								return plugin:getSetting("cover_cache_enabled") ~= false
-							end,
-							callback = function()
-								local current = plugin:getSetting("cover_cache_enabled") ~= false
-								plugin:saveSetting("cover_cache_enabled", not current)
-								UIManager:show(InfoMessage:new {
-									text = not current and
-										_("Cover cache enabled.\n\nPreviously downloaded covers can be reused.") or
-										_("Cover cache disabled.\n\nCovers will be fetched from the server each time."),
-									timeout = 2,
-								})
-							end,
-						},
-						{
-							text = _("Advanced"),
-							sub_item_table = {
-								{
-									text = _("Cache Size (MB)"),
-									callback = function()
-										plugin:showCoverCacheSizeDialog()
-									end,
-								},
-								{
-									text = _("Cache TTL (minutes)"),
-									callback = function()
-										plugin:showCoverCacheTTLDialog()
-									end,
-								},
-								{
-									text = _("Clear Cover Cache"),
-									callback = function()
-										plugin:clearCoverCache()
-									end,
-								},
-							},
-						},
-					},
-				},
-				{
-					text = _("Display Mode"),
-					sub_item_table = {
-						{
-							text = _("List View"),
-							checked_func = function()
-								local mode = plugin.settings.display_mode
-								return mode == "list" or mode == nil
-							end,
-							callback = function()
-								plugin.settings.display_mode = "list"
-								plugin.opds_settings:saveSetting("settings", plugin.settings)
-								plugin.opds_settings:flush()
-								UIManager:show(InfoMessage:new {
-									text = _("Display mode set to List View.\n\nChanges will apply when you next browse a catalog."),
-									timeout = 2,
-								})
-							end,
-						},
-						{
-							text = _("Grid View"),
-							checked_func = function()
-								return plugin.settings.display_mode == "grid"
-							end,
-							callback = function()
-								plugin.settings.display_mode = "grid"
-								plugin.opds_settings:saveSetting("settings", plugin.settings)
-								plugin.opds_settings:flush()
-								UIManager:show(InfoMessage:new {
-									text = _("Display mode set to Grid View.\n\nChanges will apply when you next browse a catalog."),
-									timeout = 2,
-								})
-							end,
-						},
-					},
-				},
-				{
-					text = _("List View Settings"),
-					sub_item_table = {
-						{
-							text = _("Cover Size"),
-							callback = function()
-								plugin:showCoverSizeMenu()
-							end,
-						},
-					},
-				},
-				{
-					text = _("Grid View Settings"),
-					sub_item_table = {
-						{
-							text = _("Grid Layout"),
-							callback = function()
-								plugin:showGridLayoutMenu()
-							end,
-						},
-						{
-							text = _("Grid Borders"),
-							callback = function()
-								plugin:showGridBorderMenu()
-							end,
-						},
-					},
-				},
-				{
-					text = _("Font & Text"),
-					sub_item_table = {
-						{
-							text = _("Use Same Font for All"),
-							checked_func = function()
-								return plugin:getSetting("use_same_font")
-							end,
-							callback = function()
-								local current = plugin:getSetting("use_same_font")
-								plugin:saveSetting("use_same_font", not current)
-								UIManager:show(InfoMessage:new {
-									text = not current and
-										_("Now using the same font for title and details.\n\nChanges apply on next catalog browse.") or
-										_("Now using separate fonts for title and details.\n\nChanges apply on next catalog browse."),
-									timeout = 2,
-								})
-							end,
-						},
-						{
-							text = _("Title Settings"),
-							sub_item_table = {
-								{
-									text = _("Title Font"),
-									callback = function()
-										plugin:showFontSelectionMenu("title_font", _("Title Font"))
-									end,
-								},
-								{
-									text = _("Title Size"),
-									callback = function()
-										plugin:showSizeSelectionMenu("title_size", _("Title Font Size"), 12, 24, 16)
-									end,
-								},
-								{
-									text = _("Title Bold"),
-									checked_func = function()
-										return plugin:getSetting("title_bold")
-									end,
-									callback = function()
-										local current = plugin:getSetting("title_bold")
-										plugin:saveSetting("title_bold", not current)
-										UIManager:show(InfoMessage:new {
-											text = not current and
-												_("Title is now bold.") or
-												_("Title is now regular weight."),
-											timeout = 2,
-										})
-									end,
-								},
-							},
-						},
-						{
-							text = _("Information Settings"),
-							sub_item_table = {
-								{
-									text = _("Info Font"),
-									enabled_func = function()
-										return not plugin:getSetting("use_same_font")
-									end,
-									callback = function()
-										plugin:showFontSelectionMenu("info_font", _("Information Font"))
-									end,
-								},
-								{
-									text = _("Info Size"),
-									callback = function()
-										plugin:showSizeSelectionMenu("info_size", _("Information Font Size"), 10,
-											20, 14)
-									end,
-								},
-								{
-									text = _("Info Bold"),
-									checked_func = function()
-										return plugin:getSetting("info_bold")
-									end,
-									callback = function()
-										local current = plugin:getSetting("info_bold")
-										plugin:saveSetting("info_bold", not current)
-										UIManager:show(InfoMessage:new {
-											text = not current and
-												_("Information text is now bold.") or
-												_("Information text is now regular weight."),
-											timeout = 2,
-										})
-									end,
-								},
-								{
-									text = _("Info Color"),
-									sub_item_table = {
-										{
-											text = _("Dark Gray (Subtle)"),
-											checked_func = function()
-												return plugin:getSetting("info_color") == "dark_gray"
-											end,
-											callback = function()
-												plugin:saveSetting("info_color", "dark_gray")
-												UIManager:show(InfoMessage:new {
-													text = _("Information text color set to dark gray."),
-													timeout = 2,
-												})
-											end,
-										},
-										{
-											text = _("Black (High Contrast)"),
-											checked_func = function()
-												return plugin:getSetting("info_color") == "black"
-											end,
-											callback = function()
-												plugin:saveSetting("info_color", "black")
-												UIManager:show(InfoMessage:new {
-													text = _("Information text color set to black."),
-													timeout = 2,
-												})
-											end,
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				{
-					text = _("Developer"),
-					sub_item_table = {
-						{
-							text = _("Debug Mode"),
-							checked_func = function()
-								return plugin.settings.debug_mode == true
-							end,
-							callback = function()
-								plugin.settings.debug_mode = not plugin.settings.debug_mode
-								plugin.opds_settings:saveSetting("settings", plugin.settings)
-								plugin.opds_settings:flush()
-								UIManager:show(InfoMessage:new {
-									text = plugin.settings.debug_mode and
-										_("Debug mode enabled.\n\nDetailed logging is now active.") or
-										_("Debug mode disabled.\n\nNormal logging restored."),
-									timeout = 2,
-								})
-							end,
-						},
-					},
-				},
-				{
-					text = T(_("About OPDS Plus v%1"), Version.VERSION),
-					callback = function()
-						UIManager:show(InfoMessage:new {
-							text = T(_("OPDS Plus Plugin\nVersion: %1\n\nAn enhanced OPDS catalog browser with cover display support.\n\nFeatures:\n• List and Grid view modes\n• Customizable covers and fonts\n• Grid border options\n\nBased on KOReader's OPDS plugin"), Version.VERSION),
-							timeout = 5,
-						})
-					end,
-				},
-			},
-		},
-	}
+  return {
+    {
+      text = _("Browse Catalogs"),
+      callback = function()
+        plugin:onShowOPDSPlusCatalog()
+      end,
+    },
+    {
+      text = _("Settings"),
+      sub_item_table = {
+        {
+          text = _("Cover Settings"),
+          sub_item_table = {
+            {
+              text = _("Prefer Large Covers"),
+              checked_func = function()
+                return plugin:getSetting("prefer_large_covers") == true
+              end,
+              callback = function()
+                local current = plugin:getSetting("prefer_large_covers") == true
+                plugin:saveSetting("prefer_large_covers", not current)
+                UIManager:show(InfoMessage:new {
+                  text = not current and
+                      _("High-quality cover source enabled.\n\nChanges apply on next catalog browse.") or
+                      _("Fast thumbnail cover source enabled.\n\nChanges apply on next catalog browse."),
+                  timeout = 2,
+                })
+              end,
+            },
+            {
+              text = _("Enable Cover Cache"),
+              checked_func = function()
+                return plugin:getSetting("cover_cache_enabled") ~= false
+              end,
+              callback = function()
+                local current = plugin:getSetting("cover_cache_enabled") ~= false
+                plugin:saveSetting("cover_cache_enabled", not current)
+                UIManager:show(InfoMessage:new {
+                  text = not current and
+                      _("Cover cache enabled.\n\nPreviously downloaded covers can be reused.") or
+                      _("Cover cache disabled.\n\nCovers will be fetched from the server each time."),
+                  timeout = 2,
+                })
+              end,
+            },
+            {
+              text = _("Advanced"),
+              sub_item_table = {
+                {
+                  text = _("Cache Size (MB)"),
+                  callback = function()
+                    plugin:showCoverCacheSizeDialog()
+                  end,
+                },
+                {
+                  text = _("Cache TTL (minutes)"),
+                  callback = function()
+                    plugin:showCoverCacheTTLDialog()
+                  end,
+                },
+                {
+                  text = _("Clear Cover Cache"),
+                  callback = function()
+                    plugin:clearCoverCache()
+                  end,
+                },
+              },
+            },
+          },
+        },
+        {
+          text = _("Display Mode"),
+          sub_item_table = {
+            {
+              text = _("List View"),
+              checked_func = function()
+                local mode = plugin.settings.display_mode
+                return mode == "list" or mode == nil
+              end,
+              callback = function()
+                plugin.settings.display_mode = "list"
+                plugin.opds_settings:saveSetting("settings", plugin.settings)
+                plugin.opds_settings:flush()
+                UIManager:show(InfoMessage:new {
+                  text = _("Display mode set to List View.\n\nChanges will apply when you next browse a catalog."),
+                  timeout = 2,
+                })
+              end,
+            },
+            {
+              text = _("Grid View"),
+              checked_func = function()
+                return plugin.settings.display_mode == "grid"
+              end,
+              callback = function()
+                plugin.settings.display_mode = "grid"
+                plugin.opds_settings:saveSetting("settings", plugin.settings)
+                plugin.opds_settings:flush()
+                UIManager:show(InfoMessage:new {
+                  text = _("Display mode set to Grid View.\n\nChanges will apply when you next browse a catalog."),
+                  timeout = 2,
+                })
+              end,
+            },
+          },
+        },
+        {
+          text = _("List View Settings"),
+          sub_item_table = {
+            {
+              text = _("Cover Size"),
+              callback = function()
+                plugin:showCoverSizeMenu()
+              end,
+            },
+          },
+        },
+        {
+          text = _("Grid View Settings"),
+          sub_item_table = {
+            {
+              text = _("Grid Layout"),
+              callback = function()
+                plugin:showGridLayoutMenu()
+              end,
+            },
+            {
+              text = _("Grid Borders"),
+              callback = function()
+                plugin:showGridBorderMenu()
+              end,
+            },
+          },
+        },
+        {
+          text = _("Font & Text"),
+          sub_item_table = {
+            {
+              text = _("Use Same Font for All"),
+              checked_func = function()
+                return plugin:getSetting("use_same_font")
+              end,
+              callback = function()
+                local current = plugin:getSetting("use_same_font")
+                plugin:saveSetting("use_same_font", not current)
+                UIManager:show(InfoMessage:new {
+                  text = not current and
+                      _("Now using the same font for title and details.\n\nChanges apply on next catalog browse.") or
+                      _("Now using separate fonts for title and details.\n\nChanges apply on next catalog browse."),
+                  timeout = 2,
+                })
+              end,
+            },
+            {
+              text = _("Title Settings"),
+              sub_item_table = {
+                {
+                  text = _("Title Font"),
+                  callback = function()
+                    plugin:showFontSelectionMenu("title_font", _("Title Font"))
+                  end,
+                },
+                {
+                  text = _("Title Size"),
+                  callback = function()
+                    plugin:showSizeSelectionMenu("title_size", _("Title Font Size"), 12, 24, 16)
+                  end,
+                },
+                {
+                  text = _("Title Bold"),
+                  checked_func = function()
+                    return plugin:getSetting("title_bold")
+                  end,
+                  callback = function()
+                    local current = plugin:getSetting("title_bold")
+                    plugin:saveSetting("title_bold", not current)
+                    UIManager:show(InfoMessage:new {
+                      text = not current and
+                          _("Title is now bold.") or
+                          _("Title is now regular weight."),
+                      timeout = 2,
+                    })
+                  end,
+                },
+              },
+            },
+            {
+              text = _("Information Settings"),
+              sub_item_table = {
+                {
+                  text = _("Info Font"),
+                  enabled_func = function()
+                    return not plugin:getSetting("use_same_font")
+                  end,
+                  callback = function()
+                    plugin:showFontSelectionMenu("info_font", _("Information Font"))
+                  end,
+                },
+                {
+                  text = _("Info Size"),
+                  callback = function()
+                    plugin:showSizeSelectionMenu("info_size", _("Information Font Size"), 10,
+                      20, 14)
+                  end,
+                },
+                {
+                  text = _("Info Bold"),
+                  checked_func = function()
+                    return plugin:getSetting("info_bold")
+                  end,
+                  callback = function()
+                    local current = plugin:getSetting("info_bold")
+                    plugin:saveSetting("info_bold", not current)
+                    UIManager:show(InfoMessage:new {
+                      text = not current and
+                          _("Information text is now bold.") or
+                          _("Information text is now regular weight."),
+                      timeout = 2,
+                    })
+                  end,
+                },
+                {
+                  text = _("Info Color"),
+                  sub_item_table = {
+                    {
+                      text = _("Dark Gray (Subtle)"),
+                      checked_func = function()
+                        return plugin:getSetting("info_color") == "dark_gray"
+                      end,
+                      callback = function()
+                        plugin:saveSetting("info_color", "dark_gray")
+                        UIManager:show(InfoMessage:new {
+                          text = _("Information text color set to dark gray."),
+                          timeout = 2,
+                        })
+                      end,
+                    },
+                    {
+                      text = _("Black (High Contrast)"),
+                      checked_func = function()
+                        return plugin:getSetting("info_color") == "black"
+                      end,
+                      callback = function()
+                        plugin:saveSetting("info_color", "black")
+                        UIManager:show(InfoMessage:new {
+                          text = _("Information text color set to black."),
+                          timeout = 2,
+                        })
+                      end,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        {
+          text = _("Developer"),
+          sub_item_table = {
+            {
+              text = _("Debug Mode"),
+              checked_func = function()
+                return plugin.settings.debug_mode == true
+              end,
+              callback = function()
+                plugin.settings.debug_mode = not plugin.settings.debug_mode
+                plugin.opds_settings:saveSetting("settings", plugin.settings)
+                plugin.opds_settings:flush()
+                UIManager:show(InfoMessage:new {
+                  text = plugin.settings.debug_mode and
+                      _("Debug mode enabled.\n\nDetailed logging is now active.") or
+                      _("Debug mode disabled.\n\nNormal logging restored."),
+                  timeout = 2,
+                })
+              end,
+            },
+          },
+        },
+        {
+          text = T(_("About OPDS++ v%1"), Version.VERSION),
+          callback = function()
+            UIManager:show(InfoMessage:new {
+              text = T(_("OPDS++ Plugin\nVersion: %1\n\nAn enhanced OPDS catalog browser with cover display support.\n\nFeatures:\n• List and Grid view modes\n• Customizable covers and fonts\n• Grid border options\n\nBased on KOReader's OPDS plugin"), Version.VERSION),
+              timeout = 5,
+            })
+          end,
+        },
+      },
+    },
+  }
 end
 
 return SettingsMenu

--- a/core/download_manager.lua
+++ b/core/download_manager.lua
@@ -28,25 +28,25 @@ local DownloadManager = {}
 -- @param link table Acquisition link with href and type
 -- @return string|nil File extension or nil if unsupported
 function DownloadManager.getFiletype(link)
-	local filetype = util.getFileNameSuffix(link.href)
-	if not DocumentRegistry:hasProvider("dummy." .. filetype) then
-		filetype = nil
-	end
-	if not filetype and DocumentRegistry:hasProvider(nil, link.type) then
-		filetype = DocumentRegistry:mimeToExt(link.type)
-	end
-	return filetype
+  local filetype = util.getFileNameSuffix(link.href)
+  if not DocumentRegistry:hasProvider("dummy." .. filetype) then
+    filetype = nil
+  end
+  if not filetype and DocumentRegistry:hasProvider(nil, link.type) then
+    filetype = DocumentRegistry:mimeToExt(link.type)
+  end
+  return filetype
 end
 
 -- Get the current download directory based on context
 -- @param browser table OPDSBrowser instance
 -- @return string Download directory path
 function DownloadManager.getCurrentDownloadDir(browser)
-	if browser.sync then
-		return browser.settings.sync_dir
-	else
-		return G_reader_settings:readSetting("download_dir") or G_reader_settings:readSetting("lastdir")
-	end
+  if browser.sync then
+    return browser.settings.sync_dir
+  else
+    return G_reader_settings:readSetting("download_dir") or G_reader_settings:readSetting("lastdir")
+  end
 end
 
 -- Build local download path for a file
@@ -56,13 +56,13 @@ end
 -- @param remote_url string URL to download from
 -- @return string Local file path
 function DownloadManager.getLocalDownloadPath(browser, filename, filetype, remote_url)
-	local download_dir = DownloadManager.getCurrentDownloadDir(browser)
+  local download_dir = DownloadManager.getCurrentDownloadDir(browser)
 
-	filename = filename and filename .. "." .. filetype:lower()
-		or browser:getServerFileName(remote_url, filetype)
-	filename = util.getSafeFilename(filename, download_dir)
-	filename = (download_dir ~= "/" and download_dir or "") .. '/' .. filename
-	return util.fixUtf8(filename, "_")
+  filename = filename and filename .. "." .. filetype:lower()
+      or browser:getServerFileName(remote_url, filetype)
+  filename = util.getSafeFilename(filename, download_dir)
+  filename = (download_dir ~= "/" and download_dir or "") .. '/' .. filename
+  return util.fixUtf8(filename, "_")
 end
 
 -- Download a file from remote URL to local path
@@ -74,54 +74,54 @@ end
 -- @param caller_callback function|nil Callback function on success
 -- @return boolean True if download succeeded
 function DownloadManager.downloadFile(browser, local_path, remote_url, username, password, caller_callback)
-	logger.dbg("Downloading file", local_path, "from", remote_url)
-	local code, headers, status
-	local parsed = url.parse(remote_url)
+  logger.dbg("Downloading file", local_path, "from", remote_url)
+  local code, headers, status
+  local parsed = url.parse(remote_url)
 
-	if parsed.scheme == "http" or parsed.scheme == "https" then
-		socketutil:set_timeout(socketutil.FILE_BLOCK_TIMEOUT, socketutil.FILE_TOTAL_TIMEOUT)
-		code, headers, status = socket.skip(1, http.request {
-			url      = remote_url,
-			headers  = {
-				["Accept-Encoding"] = "identity",
-			},
-			sink     = ltn12.sink.file(io.open(local_path, "w")),
-			user     = username,
-			password = password,
-		})
-		socketutil:reset_timeout()
-	else
-		UIManager:show(InfoMessage:new {
-			text = T(_("Invalid protocol:\n%1"), parsed.scheme),
-		})
-		return false
-	end
+  if parsed.scheme == "http" or parsed.scheme == "https" then
+    socketutil:set_timeout(socketutil.FILE_BLOCK_TIMEOUT, socketutil.FILE_TOTAL_TIMEOUT)
+    code, headers, status = socket.skip(1, http.request {
+      url      = remote_url,
+      headers  = {
+        ["Accept-Encoding"] = "identity",
+      },
+      sink     = ltn12.sink.file(io.open(local_path, "w")),
+      user     = username,
+      password = password,
+    })
+    socketutil:reset_timeout()
+  else
+    UIManager:show(InfoMessage:new {
+      text = T(_("Invalid protocol:\n%1"), parsed.scheme),
+    })
+    return false
+  end
 
-	if code == 200 then
-		logger.dbg("File downloaded to", local_path)
-		if caller_callback then
-			caller_callback(local_path)
-		end
-		return true
-	elseif code == Constants.HTTP_STATUS.FOUND and remote_url:match("^https") and headers.location:match("^http[^s]") then
-		util.removeFile(local_path)
-		UIManager:show(InfoMessage:new {
-			text = T(_("Insecure HTTPS → HTTP downgrade attempted by redirect from:\n\n'%1'\n\nto\n\n'%2'.\n\nPlease inform the server administrator that many clients disallow this because it could be a downgrade attack."),
-				BD.url(remote_url), BD.url(headers.location)),
-			icon = "notice-warning",
-		})
-	else
-		util.removeFile(local_path)
-		logger.dbg("DownloadManager:downloadFile: Request failed:", status or code)
-		logger.dbg("DownloadManager:downloadFile: Response headers:", headers)
-		UIManager:show(InfoMessage:new {
-			text = T(_("Could not save file to:\n%1\n%2"),
-				BD.filepath(local_path),
-				status or code or "network unreachable"),
-		})
-	end
+  if code == 200 then
+    logger.dbg("File downloaded to", local_path)
+    if caller_callback then
+      caller_callback(local_path)
+    end
+    return true
+  elseif code == Constants.HTTP_STATUS.FOUND and remote_url:match("^https") and headers.location:match("^http[^s]") then
+    util.removeFile(local_path)
+    UIManager:show(InfoMessage:new {
+      text = T(_("Insecure HTTPS → HTTP downgrade attempted by redirect from:\n\n'%1'\n\nto\n\n'%2'.\n\nPlease inform the server administrator that many clients disallow this because it could be a downgrade attack."),
+        BD.url(remote_url), BD.url(headers.location)),
+      icon = "notice-warning",
+    })
+  else
+    util.removeFile(local_path)
+    logger.dbg("DownloadManager:downloadFile: Request failed:", status or code)
+    logger.dbg("DownloadManager:downloadFile: Response headers:", headers)
+    UIManager:show(InfoMessage:new {
+      text = T(_("Could not save file to:\n%1\n%2"),
+        BD.filepath(local_path),
+        status or code or "network unreachable"),
+    })
+  end
 
-	return false
+  return false
 end
 
 -- Check if file exists and prompt user, then download
@@ -132,81 +132,81 @@ end
 -- @param password string|nil Optional HTTP auth password
 -- @param caller_callback function|nil Callback function on success
 function DownloadManager.checkDownloadFile(browser, local_path, remote_url, username, password, caller_callback)
-	local function download()
-		UIManager:scheduleIn(Constants.UI_TIMING.DOWNLOAD_SCHEDULE_DELAY, function()
-			DownloadManager.downloadFile(browser, local_path, remote_url, username, password, caller_callback)
-		end)
-		UIManager:show(InfoMessage:new {
-			text = _("Downloading…"),
-			timeout = Constants.UI_TIMING.NOTIFICATION_TIMEOUT,
-		})
-	end
+  local function download()
+    UIManager:scheduleIn(Constants.UI_TIMING.DOWNLOAD_SCHEDULE_DELAY, function()
+      DownloadManager.downloadFile(browser, local_path, remote_url, username, password, caller_callback)
+    end)
+    UIManager:show(InfoMessage:new {
+      text = _("Downloading…"),
+      timeout = Constants.UI_TIMING.NOTIFICATION_TIMEOUT,
+    })
+  end
 
-	if lfs.attributes(local_path) then
-		UIManager:show(ConfirmBox:new {
-			text = T(_("The file %1 already exists. Do you want to overwrite it?"), BD.filepath(local_path)),
-			ok_text = _("Overwrite"),
-			ok_callback = function()
-				download()
-			end,
-		})
-	else
-		download()
-	end
+  if lfs.attributes(local_path) then
+    UIManager:show(ConfirmBox:new {
+      text = T(_("The file %1 already exists. Do you want to overwrite it?"), BD.filepath(local_path)),
+      ok_text = _("Overwrite"),
+      ok_callback = function()
+        download()
+      end,
+    })
+  else
+    download()
+  end
 end
 
 -- Download all items in the download queue
 -- @param browser table OPDSBrowser instance
 -- @return number Count of successfully downloaded files
 function DownloadManager.downloadDownloadList(browser)
-	local info = InfoMessage:new { text = _("Downloading… (tap to cancel)") }
-	UIManager:show(info)
-	UIManager:forceRePaint()
+  local info = InfoMessage:new { text = _("Downloading… (tap to cancel)") }
+  UIManager:show(info)
+  UIManager:forceRePaint()
 
-	local completed, downloaded = Trapper:dismissableRunInSubprocess(function()
-		local dl = {}
-		for _, item in ipairs(browser.downloads) do
-			if DownloadManager.downloadFile(browser, item.file, item.url, item.username, item.password) then
-				dl[item.file] = true
-			end
-		end
-		return dl
-	end, info)
+  local completed, downloaded = Trapper:dismissableRunInSubprocess(function()
+    local dl = {}
+    for _, item in ipairs(browser.downloads) do
+      if DownloadManager.downloadFile(browser, item.file, item.url, item.username, item.password) then
+        dl[item.file] = true
+      end
+    end
+    return dl
+  end, info)
 
-	if completed then
-		UIManager:close(info)
-	end
+  if completed then
+    UIManager:close(info)
+  end
 
-	local dl_count = #browser.downloads
-	if dl_count and dl_count > 0 then
-		for i = dl_count, 1, -1 do
-			local item = browser.downloads[i]
-			if downloaded and downloaded[item.file] then
-				table.remove(browser.downloads, i)
-			else -- if subprocess has been interrupted, check for the downloaded file
-				local attr = lfs.attributes(item.file)
-				if attr then
-					if attr.size > 0 then
-						table.remove(browser.downloads, i)
-					else -- incomplete download
-						os.remove(item.file)
-					end
-				end
-			end
-		end
-	end
+  local dl_count = #browser.downloads
+  if dl_count and dl_count > 0 then
+    for i = dl_count, 1, -1 do
+      local item = browser.downloads[i]
+      if downloaded and downloaded[item.file] then
+        table.remove(browser.downloads, i)
+      else -- if subprocess has been interrupted, check for the downloaded file
+        local attr = lfs.attributes(item.file)
+        if attr then
+          if attr.size > 0 then
+            table.remove(browser.downloads, i)
+          else -- incomplete download
+            os.remove(item.file)
+          end
+        end
+      end
+    end
+  end
 
-	dl_count = dl_count - #browser.downloads
-	if dl_count > 0 then
-		browser:updateDownloadListItemTable()
-		browser.download_list_updated = true
-		StateManager.getInstance():markDirty()
-		UIManager:show(InfoMessage:new {
-			text = T(N_("1 book downloaded", "%1 books downloaded", dl_count), dl_count)
-		})
-	end
+  dl_count = dl_count - #browser.downloads
+  if dl_count > 0 then
+    browser:updateDownloadListItemTable()
+    browser.download_list_updated = true
+    StateManager.getInstance():markDirty()
+    UIManager:show(InfoMessage:new {
+      text = T(N_("1 book downloaded", "%1 books downloaded", dl_count), dl_count)
+    })
+  end
 
-	return dl_count
+  return dl_count
 end
 
 -- Download pending sync items
@@ -214,104 +214,104 @@ end
 -- @param dl_list table List of items to download
 -- @return table|nil List of duplicate files or nil
 function DownloadManager.downloadPendingSyncs(browser, dl_list)
-	local function dismissable_download()
-		local info = InfoMessage:new { text = _("Downloading… (tap to cancel)") }
-		UIManager:show(info)
-		UIManager:forceRePaint()
+  local function dismissable_download()
+    local info = InfoMessage:new { text = _("Downloading… (tap to cancel)") }
+    UIManager:show(info)
+    UIManager:forceRePaint()
 
-		local completed, downloaded, duplicate_list = Trapper:dismissableRunInSubprocess(function()
-			local dl = {}
-			local dupe_list = {}
-			for _, item in ipairs(dl_list) do
-				if browser.sync_server_list[item.catalog] then
-					if lfs.attributes(item.file) and not browser.sync_force then
-						table.insert(dupe_list, item)
-					else
-						if DownloadManager.downloadFile(browser, item.file, item.url, item.username, item.password) then
-							dl[item.file] = true
-						end
-					end
-				end
-			end
-			return dl, dupe_list
-		end, info)
+    local completed, downloaded, duplicate_list = Trapper:dismissableRunInSubprocess(function()
+      local dl = {}
+      local dupe_list = {}
+      for _, item in ipairs(dl_list) do
+        if browser.sync_server_list[item.catalog] then
+          if lfs.attributes(item.file) and not browser.sync_force then
+            table.insert(dupe_list, item)
+          else
+            if DownloadManager.downloadFile(browser, item.file, item.url, item.username, item.password) then
+              dl[item.file] = true
+            end
+          end
+        end
+      end
+      return dl, dupe_list
+    end, info)
 
-		-- clear the dupe_list if this is a skip dups runs - we needed to weed them out, but we don't want to consider them
-		if browser.sync_skip then duplicate_list = {} end
-		if completed then
-			UIManager:close(info)
-		end
+    -- clear the dupe_list if this is a skip dups runs - we needed to weed them out, but we don't want to consider them
+    if browser.sync_skip then duplicate_list = {} end
+    if completed then
+      UIManager:close(info)
+    end
 
-		local dl_count = 0
-		local dl_size = #dl_list
-		for i = dl_size, 1, -1 do
-			local item = dl_list[i]
-			if downloaded and downloaded[item.file] then
-				dl_count = dl_count + 1
-				table.remove(dl_list, i)
-			else -- if subprocess has been interrupted, check for the downloaded file
-				local attr = lfs.attributes(item.file)
-				if attr then
-					if attr.size > 0 then
-						table.remove(dl_list, i)
-						-- Only count files touched within the freshness window
-						if attr.modification > os.time() - Constants.SYNC.DOWNLOAD_FRESHNESS_SECONDS then
-							dl_count = dl_count + 1
-						end
-					else -- incomplete download
-						os.remove(item.file)
-					end
-				end
-			end
-		end
+    local dl_count = 0
+    local dl_size = #dl_list
+    for i = dl_size, 1, -1 do
+      local item = dl_list[i]
+      if downloaded and downloaded[item.file] then
+        dl_count = dl_count + 1
+        table.remove(dl_list, i)
+      else -- if subprocess has been interrupted, check for the downloaded file
+        local attr = lfs.attributes(item.file)
+        if attr then
+          if attr.size > 0 then
+            table.remove(dl_list, i)
+            -- Only count files touched within the freshness window
+            if attr.modification > os.time() - Constants.SYNC.DOWNLOAD_FRESHNESS_SECONDS then
+              dl_count = dl_count + 1
+            end
+          else -- incomplete download
+            os.remove(item.file)
+          end
+        end
+      end
+    end
 
-		local duplicate_count = duplicate_list and #duplicate_list or 0
-		dl_count = dl_count - duplicate_count
+    local duplicate_count = duplicate_list and #duplicate_list or 0
+    dl_count = dl_count - duplicate_count
 
-		-- Make downloaded count timeout if there's a duplicate file prompt
-		local timeout = nil
-		if duplicate_count > 0 then
-			timeout = Constants.UI_TIMING.DUPLICATE_NOTIFICATION_TIMEOUT
-		end
+    -- Make downloaded count timeout if there's a duplicate file prompt
+    local timeout = nil
+    if duplicate_count > 0 then
+      timeout = Constants.UI_TIMING.DUPLICATE_NOTIFICATION_TIMEOUT
+    end
 
-		if dl_count > 0 then
-			UIManager:show(InfoMessage:new {
-				text = T(N_("1 book downloaded", "%1 books downloaded", dl_count), dl_count),
-				timeout = timeout,
-			})
-		end
+    if dl_count > 0 then
+      UIManager:show(InfoMessage:new {
+        text = T(N_("1 book downloaded", "%1 books synced", dl_count), dl_count),
+        timeout = timeout,
+      })
+    end
 
-		StateManager.getInstance():markDirty()
-		return duplicate_list
-	end
+    StateManager.getInstance():markDirty()
+    return duplicate_list
+  end
 
-	return dismissable_download()
+  return dismissable_download()
 end
 
 -- Add item to download queue
 -- @param browser table OPDSBrowser instance
 -- @param download_item table Item with file, url, username, password, info, catalog
 function DownloadManager.addToDownloadQueue(browser, download_item)
-	table.insert(browser.downloads, download_item)
-	StateManager.getInstance():markDirty()
+  table.insert(browser.downloads, download_item)
+  StateManager.getInstance():markDirty()
 end
 
 -- Remove item from download queue
 -- @param browser table OPDSBrowser instance
 -- @param index number Index of item to remove
 function DownloadManager.removeFromDownloadQueue(browser, index)
-	table.remove(browser.downloads, index)
-	StateManager.getInstance():markDirty()
+  table.remove(browser.downloads, index)
+  StateManager.getInstance():markDirty()
 end
 
 -- Clear all items from download queue
 -- @param browser table OPDSBrowser instance
 function DownloadManager.clearDownloadQueue(browser)
-	for i in ipairs(browser.downloads) do
-		browser.downloads[i] = nil
-	end
-	browser.download_list_updated = true
-	StateManager.getInstance():markDirty()
+  for i in ipairs(browser.downloads) do
+    browser.downloads[i] = nil
+  end
+  browser.download_list_updated = true
+  StateManager.getInstance():markDirty()
 end
 
 return DownloadManager

--- a/core/download_manager.lua
+++ b/core/download_manager.lua
@@ -178,17 +178,19 @@ function DownloadManager.downloadDownloadList(browser)
 	end
 
 	local dl_count = #browser.downloads
-	for i = dl_count, 1, -1 do
-		local item = browser.downloads[i]
-		if downloaded and downloaded[item.file] then
-			table.remove(browser.downloads, i)
-		else -- if subprocess has been interrupted, check for the downloaded file
-			local attr = lfs.attributes(item.file)
-			if attr then
-				if attr.size > 0 then
-					table.remove(browser.downloads, i)
-				else -- incomplete download
-					os.remove(item.file)
+	if dl_count and dl_count > 0 then
+		for i = dl_count, 1, -1 do
+			local item = browser.downloads[i]
+			if downloaded and downloaded[item.file] then
+				table.remove(browser.downloads, i)
+			else -- if subprocess has been interrupted, check for the downloaded file
+				local attr = lfs.attributes(item.file)
+				if attr then
+					if attr.size > 0 then
+						table.remove(browser.downloads, i)
+					else -- incomplete download
+						os.remove(item.file)
+					end
 				end
 			end
 		end
@@ -234,6 +236,8 @@ function DownloadManager.downloadPendingSyncs(browser, dl_list)
 			return dl, dupe_list
 		end, info)
 
+		-- clear the dupe_list if this is a skip dups runs - we needed to weed them out, but we don't want to consider them
+		if browser.sync_skip then duplicate_list = {} end
 		if completed then
 			UIManager:close(info)
 		end

--- a/core/state_manager.lua
+++ b/core/state_manager.lua
@@ -1,4 +1,4 @@
--- State Manager for OPDS Plus
+-- State Manager for OPDS++
 -- Centralizes state change tracking and persistence notifications
 -- Reduces direct _manager.updated coupling throughout the codebase
 
@@ -12,59 +12,59 @@ local instance = nil
 -- @param plugin table Optional plugin instance to initialize with
 -- @return StateManager
 function StateManager.getInstance(plugin)
-	if not instance then
-		instance = setmetatable({
-			_plugin = plugin,
-			_dirty = false,
-			_change_listeners = {},
-		}, StateManager)
-	elseif plugin then
-		instance._plugin = plugin
-	end
-	return instance
+  if not instance then
+    instance = setmetatable({
+      _plugin = plugin,
+      _dirty = false,
+      _change_listeners = {},
+    }, StateManager)
+  elseif plugin then
+    instance._plugin = plugin
+  end
+  return instance
 end
 
 --- Reset the singleton (primarily for testing)
 function StateManager.reset()
-	instance = nil
+  instance = nil
 end
 
 --- Initialize with a plugin instance
 -- @param plugin table Plugin instance (OPDS main module)
 function StateManager:init(plugin)
-	self._plugin = plugin
-	self._dirty = false
+  self._plugin = plugin
+  self._dirty = false
 end
 
 --- Mark state as changed (needs persistence)
 -- This replaces scattered `browser._manager.updated = true` calls
 function StateManager:markDirty()
-	self._dirty = true
-	if self._plugin then
-		self._plugin.updated = true
-	end
-	self:_notifyListeners("dirty")
+  self._dirty = true
+  if self._plugin then
+    self._plugin.updated = true
+  end
+  self:_notifyListeners("dirty")
 end
 
 --- Check if state has unsaved changes
 -- @return boolean True if there are unsaved changes
 function StateManager:isDirty()
-	return self._dirty
+  return self._dirty
 end
 
 --- Clear the dirty flag (after save)
 function StateManager:markClean()
-	self._dirty = false
-	self:_notifyListeners("clean")
+  self._dirty = false
+  self:_notifyListeners("clean")
 end
 
 --- Get the current settings data
 -- @return table Settings data table
 function StateManager:getSettings()
-	if self._plugin and self._plugin.settings then
-		return self._plugin.settings
-	end
-	return {}
+  if self._plugin and self._plugin.settings then
+    return self._plugin.settings
+  end
+  return {}
 end
 
 --- Get a specific setting value
@@ -72,62 +72,62 @@ end
 -- @param default any Default value if not set
 -- @return any Setting value or default
 function StateManager:getSetting(key, default)
-	local settings = self:getSettings()
-	if settings[key] ~= nil then
-		return settings[key]
-	end
-	return default
+  local settings = self:getSettings()
+  if settings[key] ~= nil then
+    return settings[key]
+  end
+  return default
 end
 
 --- Update a setting value and mark dirty
 -- @param key string Setting key
 -- @param value any Value to set
 function StateManager:setSetting(key, value)
-	local settings = self:getSettings()
-	settings[key] = value
-	self:markDirty()
+  local settings = self:getSettings()
+  settings[key] = value
+  self:markDirty()
 end
 
 --- Check if debug mode is enabled
 -- @return boolean True if debug mode is on
 function StateManager:isDebugMode()
-	return self:getSetting("debug_mode", false)
+  return self:getSetting("debug_mode", false)
 end
 
 --- Get display mode (list/grid)
 -- @return string "list" or "grid"
 function StateManager:getDisplayMode()
-	return self:getSetting("display_mode", "list")
+  return self:getSetting("display_mode", "list")
 end
 
 --- Set display mode
 -- @param mode string "list" or "grid"
 function StateManager:setDisplayMode(mode)
-	self:setSetting("display_mode", mode)
-	-- Also persist immediately for display mode changes
-	if self._plugin and self._plugin.opds_settings then
-		self._plugin.opds_settings:saveSetting("settings", self:getSettings())
-		self._plugin.opds_settings:flush()
-	end
+  self:setSetting("display_mode", mode)
+  -- Also persist immediately for display mode changes
+  if self._plugin and self._plugin.opds_settings then
+    self._plugin.opds_settings:saveSetting("settings", self:getSettings())
+    self._plugin.opds_settings:flush()
+  end
 end
 
 --- Get sync directory
 -- @return string|nil Sync directory path or nil
 function StateManager:getSyncDir()
-	return self:getSetting("sync_dir")
+  return self:getSetting("sync_dir")
 end
 
 --- Get maximum sync downloads
 -- @return number Maximum downloads (default 50)
 function StateManager:getMaxSyncDownloads()
-	local Constants = require("models.constants")
-	return self:getSetting("sync_max_dl", Constants.SYNC.DEFAULT_MAX_DOWNLOADS)
+  local Constants = require("models.constants")
+  return self:getSetting("sync_max_dl", Constants.SYNC.DEFAULT_MAX_DOWNLOADS)
 end
 
 --- Get filetypes filter string
 -- @return string|nil Filetypes string or nil
 function StateManager:getFiletypes()
-	return self:getSetting("filetypes")
+  return self:getSetting("filetypes")
 end
 
 -- ============================================
@@ -137,51 +137,51 @@ end
 --- Get all font settings as a table
 -- @return table Font settings with defaults applied
 function StateManager:getFontSettings()
-	local Constants = require("models.constants")
-	local defaults = Constants.DEFAULT_FONT_SETTINGS
-	return {
-		title_font = self:getSetting("title_font", defaults.title_font or "smallinfofont"),
-		title_size = self:getSetting("title_size", defaults.title_size or 16),
-		title_bold = self:getSetting("title_bold", defaults.title_bold or false),
-		info_font = self:getSetting("info_font", defaults.info_font or "smallinfofont"),
-		info_size = self:getSetting("info_size", defaults.info_size or 14),
-		info_bold = self:getSetting("info_bold", defaults.info_bold or false),
-		info_color = self:getSetting("info_color", defaults.info_color or "dark_gray"),
-		use_same_font = self:getSetting("use_same_font", defaults.use_same_font or false),
-	}
+  local Constants = require("models.constants")
+  local defaults = Constants.DEFAULT_FONT_SETTINGS
+  return {
+    title_font = self:getSetting("title_font", defaults.title_font or "smallinfofont"),
+    title_size = self:getSetting("title_size", defaults.title_size or 16),
+    title_bold = self:getSetting("title_bold", defaults.title_bold or false),
+    info_font = self:getSetting("info_font", defaults.info_font or "smallinfofont"),
+    info_size = self:getSetting("info_size", defaults.info_size or 14),
+    info_bold = self:getSetting("info_bold", defaults.info_bold or false),
+    info_color = self:getSetting("info_color", defaults.info_color or "dark_gray"),
+    use_same_font = self:getSetting("use_same_font", defaults.use_same_font or false),
+  }
 end
 
 --- Get cover size settings for list view
 -- @return table Cover settings {preset_name, ratio}
 function StateManager:getCoverSettings()
-	local Constants = require("models.constants")
-	return {
-		preset_name = self:getSetting("cover_size_preset", "Regular"),
-		ratio = self:getSetting("cover_height_ratio", Constants.DEFAULT_COVER_HEIGHT_RATIO),
-	}
+  local Constants = require("models.constants")
+  return {
+    preset_name = self:getSetting("cover_size_preset", "Regular"),
+    ratio = self:getSetting("cover_height_ratio", Constants.DEFAULT_COVER_HEIGHT_RATIO),
+  }
 end
 
 --- Get grid layout settings
 -- @return table Grid settings {preset_name, columns}
 function StateManager:getGridLayoutSettings()
-	local Constants = require("models.constants")
-	local defaults = Constants.DEFAULT_GRID_SETTINGS
-	return {
-		preset_name = self:getSetting("grid_size_preset", defaults.size_preset or "Balanced"),
-		columns = self:getSetting("grid_columns", defaults.columns or 3),
-	}
+  local Constants = require("models.constants")
+  local defaults = Constants.DEFAULT_GRID_SETTINGS
+  return {
+    preset_name = self:getSetting("grid_size_preset", defaults.size_preset or "Balanced"),
+    columns = self:getSetting("grid_columns", defaults.columns or 3),
+  }
 end
 
 --- Get grid border settings
 -- @return table Border settings {style, size, color}
 function StateManager:getGridBorderSettings()
-	local Constants = require("models.constants")
-	local defaults = Constants.DEFAULT_GRID_BORDER_SETTINGS
-	return {
-		style = self:getSetting("grid_border_style", defaults.border_style or "none"),
-		size = self:getSetting("grid_border_size", defaults.border_size or 2),
-		color = self:getSetting("grid_border_color", defaults.border_color or "dark_gray"),
-	}
+  local Constants = require("models.constants")
+  local defaults = Constants.DEFAULT_GRID_BORDER_SETTINGS
+  return {
+    style = self:getSetting("grid_border_style", defaults.border_style or "none"),
+    size = self:getSetting("grid_border_size", defaults.border_size or 2),
+    color = self:getSetting("grid_border_color", defaults.border_color or "dark_gray"),
+  }
 end
 
 -- ============================================
@@ -190,24 +190,24 @@ end
 -- @param listener function Callback function(event_type)
 -- @return number Listener ID for removal
 function StateManager:addChangeListener(listener)
-	table.insert(self._change_listeners, listener)
-	return #self._change_listeners
+  table.insert(self._change_listeners, listener)
+  return #self._change_listeners
 end
 
 --- Remove a change listener
 -- @param listener_id number ID returned from addChangeListener
 function StateManager:removeChangeListener(listener_id)
-	self._change_listeners[listener_id] = nil
+  self._change_listeners[listener_id] = nil
 end
 
 --- Internal: notify all listeners of state change
 -- @param event_type string Type of event ("dirty" or "clean")
 function StateManager:_notifyListeners(event_type)
-	for _, listener in pairs(self._change_listeners) do
-		if type(listener) == "function" then
-			pcall(listener, event_type)
-		end
-	end
+  for _, listener in pairs(self._change_listeners) do
+    if type(listener) == "function" then
+      pcall(listener, event_type)
+    end
+  end
 end
 
 return StateManager

--- a/core/sync_manager.lua
+++ b/core/sync_manager.lua
@@ -256,17 +256,17 @@ function SyncManager.getSyncDownloadList(browser, url_arg)
 
 		-- First entry in table is the newest
 		-- If already downloaded, return
-		local first_href
-		if acquisitions_empty then
-			first_href = sub_table[count].url
-		else
-			first_href = sub_table[1].acquisitions[1].href
+		if not browser.sync_force or browser.sync_skip then
+			local first_href
+			if acquisitions_empty then
+				first_href = sub_table[count].url
+			else
+				first_href = sub_table[1].acquisitions[1].href
+			end
+			if first_href == browser.sync_server.last_download and not browser.sync_force then
+				return nil
+			end
 		end
-
-		if first_href == browser.sync_server.last_download and not browser.sync_force then
-			return nil
-		end
-
 		local href
 		for i, entry in ipairs(sub_table) do
 			if acquisitions_empty then
@@ -282,7 +282,7 @@ function SyncManager.getSyncDownloadList(browser, url_arg)
 			if href then
 				if href == browser.sync_server.last_download and not browser.sync_force then
 					up_to_date = true
-					break
+					if not browser.sync_skip then break end
 				else
 					table.insert(sync_table, entry)
 				end
@@ -304,7 +304,7 @@ function SyncManager.downloadPendingSyncs(browser)
 	local dl_list = browser.pending_syncs
 	local duplicate_list = DownloadManager.downloadPendingSyncs(browser, dl_list)
 
-	if duplicate_list and #duplicate_list > 0 then
+	if duplicate_list and #duplicate_list > 0 and not browser.sync_skip then
 		SyncManager.showDuplicateFilesDialog(browser, dl_list, duplicate_list)
 	end
 end
@@ -336,6 +336,7 @@ function SyncManager.showDuplicateFilesDialog(browser, dl_list, duplicate_list)
 					text = _("Overwrite"),
 					callback = function()
 						browser.sync_force = true
+						browser.sync_skip = false
 						textviewer:onClose()
 						for _, entry in ipairs(duplicate_list) do
 							table.insert(dl_list, entry)
@@ -346,9 +347,21 @@ function SyncManager.showDuplicateFilesDialog(browser, dl_list, duplicate_list)
 					end
 				},
 				{
+					text = _("Skip Duplicates"),
+					callback = function()
+						browser.sync_force = false
+						browser.sync_skip = true
+						textviewer:onClose()
+						Trapper:wrap(function()
+							DownloadManager.downloadPendingSyncs(browser, dl_list)
+						end)
+					end
+				},
+				{
 					text = _("Download copies"),
 					callback = function()
 						browser.sync_force = true
+						browser.sync_skip = false
 						textviewer:onClose()
 						local copies_dir = "copies"
 						local original_dir = util.splitFilePathName(duplicate_list[1].file)

--- a/core/sync_manager.lua
+++ b/core/sync_manager.lua
@@ -21,204 +21,204 @@ local SyncManager = {}
 --- Show dialog to set maximum number of files to sync
 -- @param browser table OPDSBrowser instance
 function SyncManager.showMaxSyncDialog(browser)
-	local current_max_dl = browser.settings.sync_max_dl or Constants.SYNC.DEFAULT_MAX_DOWNLOADS
-	local spin = SpinWidget:new {
-		title_text = _("Set maximum sync size"),
-		info_text = _("Set the max number of books to download at a time"),
-		value = current_max_dl,
-		value_min = 0,
-		value_max = Constants.SYNC.MAX_DOWNLOADS_LIMIT,
-		value_step = Constants.SYNC.STEP,
-		value_hold_step = Constants.SYNC.HOLD_STEP,
-		default_value = Constants.SYNC.DEFAULT_MAX_DOWNLOADS,
-		wrap = true,
-		ok_text = _("Save"),
-		callback = function(spin)
-			browser.settings.sync_max_dl = spin.value
-			StateManager.getInstance():markDirty()
-		end,
-	}
-	UIManager:show(spin)
+  local current_max_dl = browser.settings.sync_max_dl or Constants.SYNC.DEFAULT_MAX_DOWNLOADS
+  local spin = SpinWidget:new {
+    title_text = _("Set maximum sync size"),
+    info_text = _("Set the max number of books to download at a time"),
+    value = current_max_dl,
+    value_min = 0,
+    value_max = Constants.SYNC.MAX_DOWNLOADS_LIMIT,
+    value_step = Constants.SYNC.STEP,
+    value_hold_step = Constants.SYNC.HOLD_STEP,
+    default_value = Constants.SYNC.DEFAULT_MAX_DOWNLOADS,
+    wrap = true,
+    ok_text = _("Save"),
+    callback = function(spin)
+      browser.settings.sync_max_dl = spin.value
+      StateManager.getInstance():markDirty()
+    end,
+  }
+  UIManager:show(spin)
 end
 
 --- Show directory chooser for sync folder
 -- @param browser table OPDSBrowser instance
 function SyncManager.showSyncDirChooser(browser)
-	local force_chooser_dir
-	if Device:isAndroid() then
-		force_chooser_dir = Device.home_dir
-	end
+  local force_chooser_dir
+  if Device:isAndroid() then
+    force_chooser_dir = Device.home_dir
+  end
 
-	require("ui/downloadmgr"):new {
-		onConfirm = function(inbox)
-			logger.info("set opds sync folder", inbox)
-			browser.settings.sync_dir = inbox
-			StateManager.getInstance():markDirty()
-		end,
-	}:chooseDir(force_chooser_dir)
+  require("ui/downloadmgr"):new {
+    onConfirm = function(inbox)
+      logger.info("set opds sync folder", inbox)
+      browser.settings.sync_dir = inbox
+      StateManager.getInstance():markDirty()
+    end,
+  }:chooseDir(force_chooser_dir)
 end
 
 --- Show dialog to set file types to sync
 -- @param browser table OPDSBrowser instance
 function SyncManager.showFiletypesDialog(browser)
-	local input = browser.settings.filetypes
-	local dialog
-	dialog = InputDialog:new {
-		title = _("File types to sync"),
-		description = _("A comma separated list of desired filetypes"),
-		input_hint = _("epub, mobi"),
-		input = input,
-		buttons = {
-			{
-				{
-					text = _("Cancel"),
-					id = "close",
-					callback = function()
-						UIManager:close(dialog)
-					end,
-				},
-				{
-					text = _("Save"),
-					is_enter_default = true,
-					callback = function()
-						local str = dialog:getInputText()
-						browser.settings.filetypes = str ~= "" and str or nil
-						StateManager.getInstance():markDirty()
-						UIManager:close(dialog)
-					end,
-				},
-			},
-		},
-	}
-	UIManager:show(dialog)
-	dialog:onShowKeyboard()
+  local input = browser.settings.filetypes
+  local dialog
+  dialog = InputDialog:new {
+    title = _("File types to sync"),
+    description = _("A comma separated list of desired filetypes"),
+    input_hint = _("epub, mobi"),
+    input = input,
+    buttons = {
+      {
+        {
+          text = _("Cancel"),
+          id = "close",
+          callback = function()
+            UIManager:close(dialog)
+          end,
+        },
+        {
+          text = _("Save"),
+          is_enter_default = true,
+          callback = function()
+            local str = dialog:getInputText()
+            browser.settings.filetypes = str ~= "" and str or nil
+            StateManager.getInstance():markDirty()
+            UIManager:close(dialog)
+          end,
+        },
+      },
+    },
+  }
+  UIManager:show(dialog)
+  dialog:onShowKeyboard()
 end
 
 --- Parse filetypes string into a lookup table
 -- @param filetypes_str string Comma-separated list of filetypes
 -- @return table|nil Lookup table of filetypes, or nil if no filter
 function SyncManager.parseFiletypes(filetypes_str)
-	if not filetypes_str then
-		return nil
-	end
+  if not filetypes_str then
+    return nil
+  end
 
-	local file_list = {}
-	for filetype in util.gsplit(filetypes_str, ",") do
-		file_list[util.trim(filetype)] = true
-	end
-	return file_list
+  local file_list = {}
+  for filetype in util.gsplit(filetypes_str, ",") do
+    file_list[util.trim(filetype)] = true
+  end
+  return file_list
 end
 
 --- Check if sync is properly configured and start sync process
 -- @param browser table OPDSBrowser instance
 -- @param server_idx number|nil Index of specific server to sync (nil for all)
 function SyncManager.checkAndStartSync(browser, server_idx)
-	if not browser.settings.sync_dir then
-		UIManager:show(InfoMessage:new {
-			text = _("Please choose a folder for sync downloads first"),
-		})
-		return
-	end
+  if not browser.settings.sync_dir then
+    UIManager:show(InfoMessage:new {
+      text = _("Please choose a folder for sync downloads first"),
+    })
+    return
+  end
 
-	browser.sync = true
-	local info = InfoMessage:new {
-		text = _("Synchronizing lists…"),
-	}
-	UIManager:show(info)
-	UIManager:forceRePaint()
+  browser.sync = true
+  local info = InfoMessage:new {
+    text = _("Synchronizing lists…"),
+  }
+  UIManager:show(info)
+  UIManager:forceRePaint()
 
-	if server_idx then
-		-- Sync specific server (first item is "Downloads", so subtract 1)
-		SyncManager.fillPendingSyncs(browser, browser.servers[server_idx - 1])
-	else
-		-- Sync all servers with sync enabled
-		for _, server in ipairs(browser.servers) do
-			if server.sync then
-				SyncManager.fillPendingSyncs(browser, server)
-			end
-		end
-	end
+  if server_idx then
+    -- Sync specific server (first item is "Downloads", so subtract 1)
+    SyncManager.fillPendingSyncs(browser, browser.servers[server_idx - 1])
+  else
+    -- Sync all servers with sync enabled
+    for _, server in ipairs(browser.servers) do
+      if server.sync then
+        SyncManager.fillPendingSyncs(browser, server)
+      end
+    end
+  end
 
-	UIManager:close(info)
+  UIManager:close(info)
 
-	if #browser.pending_syncs > 0 then
-		Trapper:wrap(function()
-			SyncManager.downloadPendingSyncs(browser)
-		end)
-	else
-		UIManager:show(InfoMessage:new {
-			text = _("Up to date!"),
-		})
-	end
+  if #browser.pending_syncs > 0 then
+    Trapper:wrap(function()
+      SyncManager.downloadPendingSyncs(browser)
+    end)
+  else
+    UIManager:show(InfoMessage:new {
+      text = _("Up to date!"),
+    })
+  end
 
-	browser.sync = false
+  browser.sync = false
 end
 
 --- Fill pending syncs list for a specific server
 -- @param browser table OPDSBrowser instance
 -- @param server table Server configuration
 function SyncManager.fillPendingSyncs(browser, server)
-	-- Set browser context for this server
-	browser.root_catalog_password  = server.password
-	browser.root_catalog_raw_names = server.raw_names
-	browser.root_catalog_username  = server.username
-	browser.root_catalog_title     = server.title
-	browser.sync_server            = server
-	browser.sync_server_list       = browser.sync_server_list or {}
-	browser.sync_max_dl            = browser.settings.sync_max_dl or Constants.SYNC.DEFAULT_MAX_DOWNLOADS
+  -- Set browser context for this server
+  browser.root_catalog_password  = server.password
+  browser.root_catalog_raw_names = server.raw_names
+  browser.root_catalog_username  = server.username
+  browser.root_catalog_title     = server.title
+  browser.sync_server            = server
+  browser.sync_server_list       = browser.sync_server_list or {}
+  browser.sync_max_dl            = browser.settings.sync_max_dl or Constants.SYNC.DEFAULT_MAX_DOWNLOADS
 
-	local file_list                = SyncManager.parseFiletypes(browser.settings.filetypes)
-	local new_last_download        = nil
-	local dl_count                 = 1
+  local file_list                = SyncManager.parseFiletypes(browser.settings.filetypes)
+  local new_last_download        = nil
+  local dl_count                 = 1
 
-	local sync_list                = SyncManager.getSyncDownloadList(browser)
-	if sync_list then
-		for i, entry in ipairs(sync_list) do
-			-- Handle Project Gutenberg style entries
-			local sub_table = {}
-			local item
-			if entry.url then
-				sub_table = SyncManager.getSyncDownloadList(browser, entry.url) or {}
-			end
-			if #sub_table > 0 then
-				-- The first element seems to be most compatible. Second element has most options
-				item = sub_table[2]
-			else
-				item = entry
-			end
+  local sync_list                = SyncManager.getSyncDownloadList(browser)
+  if sync_list then
+    for i, entry in ipairs(sync_list) do
+      -- Handle Project Gutenberg style entries
+      local sub_table = {}
+      local item
+      if entry.url then
+        sub_table = SyncManager.getSyncDownloadList(browser, entry.url) or {}
+      end
+      if #sub_table > 0 then
+        -- The first element seems to be most compatible. Second element has most options
+        item = sub_table[2]
+      else
+        item = entry
+      end
 
-			for j, link in ipairs(item.acquisitions) do
-				-- Only save first link in case of several file types
-				if i == 1 and j == 1 then
-					new_last_download = link.href
-				end
-				local filetype = DownloadManager.getFiletype(link)
-				if filetype then
-					if not file_list or file_list[filetype] then
-						local filename = browser:getFileName(entry)
-						local download_path = browser:getLocalDownloadPath(filename, filetype, link.href)
-						if dl_count <= browser.sync_max_dl then
-							table.insert(browser.pending_syncs, {
-								file = download_path,
-								url = link.href,
-								username = browser.root_catalog_username,
-								password = browser.root_catalog_password,
-								catalog = server.url,
-							})
-							dl_count = dl_count + 1
-						end
-						break
-					end
-				end
-			end
-		end
-	end
+      for j, link in ipairs(item.acquisitions) do
+        -- Only save first link in case of several file types
+        if i == 1 and j == 1 then
+          new_last_download = link.href
+        end
+        local filetype = DownloadManager.getFiletype(link)
+        if filetype then
+          if not file_list or file_list[filetype] then
+            local filename = browser:getFileName(entry)
+            local download_path = browser:getLocalDownloadPath(filename, filetype, link.href)
+            if dl_count <= browser.sync_max_dl then
+              table.insert(browser.pending_syncs, {
+                file = download_path,
+                url = link.href,
+                username = browser.root_catalog_username,
+                password = browser.root_catalog_password,
+                catalog = server.url,
+              })
+              dl_count = dl_count + 1
+            end
+            break
+          end
+        end
+      end
+    end
+  end
 
-	browser.sync_server_list[server.url] = true
-	if new_last_download then
-		logger.dbg("Updating opds last download for server", server.title, "to", new_last_download)
-		browser:updateFieldInCatalog(server, "last_download", new_last_download)
-	end
+  browser.sync_server_list[server.url] = true
+  if new_last_download then
+    logger.dbg("Updating opds last download for server", server.title, "to", new_last_download)
+    browser:updateFieldInCatalog(server, "last_download", new_last_download)
+  end
 end
 
 --- Get list of books to download for sync
@@ -226,87 +226,87 @@ end
 -- @param url_arg string|nil URL to fetch (nil uses sync_server.url)
 -- @return table|nil List of entries to sync, or nil if up to date
 function SyncManager.getSyncDownloadList(browser, url_arg)
-	local sync_table = {}
-	local fetch_url = url_arg or browser.sync_server.url
-	local sub_table
-	local up_to_date = false
+  local sync_table = {}
+  local fetch_url = url_arg or browser.sync_server.url
+  local sub_table
+  local up_to_date = false
 
-	while #sync_table < browser.sync_max_dl and not up_to_date do
-		sub_table = browser:genItemTableFromURL(fetch_url)
+  while #sync_table < browser.sync_max_dl and not up_to_date do
+    sub_table = browser:genItemTableFromURL(fetch_url)
 
-		-- Handle timeout
-		if #sub_table == 0 then
-			return sync_table
-		end
+    -- Handle timeout
+    if #sub_table == 0 then
+      return sync_table
+    end
 
-		local count = 1
-		local acquisitions_empty = false
+    local count = 1
+    local acquisitions_empty = false
 
-		-- Handle Project Gutenberg style entries
-		while #sub_table[count].acquisitions == 0 do
-			if util.stringEndsWith(sub_table[count].url, ".opds") then
-				acquisitions_empty = true
-				break
-			end
-			if count == #sub_table then
-				return sync_table
-			end
-			count = count + 1
-		end
+    -- Handle Project Gutenberg style entries
+    while #sub_table[count].acquisitions == 0 do
+      if util.stringEndsWith(sub_table[count].url, ".opds") then
+        acquisitions_empty = true
+        break
+      end
+      if count == #sub_table then
+        return sync_table
+      end
+      count = count + 1
+    end
 
-		-- First entry in table is the newest
-		-- If already downloaded, return
-		if not browser.sync_force or browser.sync_skip then
-			local first_href
-			if acquisitions_empty then
-				first_href = sub_table[count].url
-			else
-				first_href = sub_table[1].acquisitions[1].href
-			end
-			if first_href == browser.sync_server.last_download and not browser.sync_force then
-				return nil
-			end
-		end
-		local href
-		for i, entry in ipairs(sub_table) do
-			if acquisitions_empty then
-				if i >= count then
-					href = entry.url
-				else
-					href = nil
-				end
-			else
-				href = entry.acquisitions[1].href
-			end
+    -- First entry in table is the newest
+    -- If 'verify' mode (neither force nor skip), stop when we hit last_download
+    if not browser.sync_force and not browser.sync_skip then
+      local first_href
+      if acquisitions_empty then
+        first_href = sub_table[count].url
+      else
+        first_href = sub_table[1].acquisitions[1].href
+      end
+      if first_href == browser.sync_server.last_download then
+        return nil
+      end
+    end
+    local href
+    for i, entry in ipairs(sub_table) do
+      if acquisitions_empty then
+        if i >= count then
+          href = entry.url
+        else
+          href = nil
+        end
+      else
+        href = entry.acquisitions[1].href
+      end
 
-			if href then
-				if href == browser.sync_server.last_download and not browser.sync_force then
-					up_to_date = true
-					if not browser.sync_skip then break end
-				else
-					table.insert(sync_table, entry)
-				end
-			end
-		end
+      if href then
+        if href == browser.sync_server.last_download and (not browser.sync_force and not browser.sync_skip) then
+          up_to_date = true
+          break
+        else
+          table.insert(sync_table, entry)
+        end
+      end
+    end
 
-		if not sub_table.hrefs.next then
-			break
-		end
-		fetch_url = sub_table.hrefs.next
-	end
+    if not sub_table.hrefs.next then
+      break
+    end
+    fetch_url = sub_table.hrefs.next
+  end
 
-	return sync_table
+  return sync_table
 end
 
 --- Download all pending sync items and handle duplicates
 -- @param browser table OPDSBrowser instance
 function SyncManager.downloadPendingSyncs(browser)
-	local dl_list = browser.pending_syncs
-	local duplicate_list = DownloadManager.downloadPendingSyncs(browser, dl_list)
+  local dl_list = browser.pending_syncs
+  local duplicate_list = DownloadManager.downloadPendingSyncs(browser, dl_list)
 
-	if duplicate_list and #duplicate_list > 0 and not browser.sync_skip then
-		SyncManager.showDuplicateFilesDialog(browser, dl_list, duplicate_list)
-	end
+  if duplicate_list and #duplicate_list > 0 and not browser.sync_skip then
+    SyncManager.showDuplicateFilesDialog(browser, dl_list, duplicate_list)
+  end
 end
 
 --- Show dialog for handling duplicate files during sync
@@ -314,76 +314,76 @@ end
 -- @param dl_list table Download list
 -- @param duplicate_list table List of duplicate files
 function SyncManager.showDuplicateFilesDialog(browser, dl_list, duplicate_list)
-	local duplicate_files = { _("These files are already on the device:") }
-	for _, entry in ipairs(duplicate_list) do
-		table.insert(duplicate_files, entry.file)
-	end
-	local text = table.concat(duplicate_files, "\n")
+  local duplicate_files = { _("These files are already on the device:") }
+  for _, entry in ipairs(duplicate_list) do
+    table.insert(duplicate_files, entry.file)
+  end
+  local text = table.concat(duplicate_files, "\n")
 
-	local textviewer
-	textviewer = TextViewer:new {
-		title = _("Duplicate files"),
-		text = text,
-		buttons_table = {
-			{
-				{
-					text = _("Do nothing"),
-					callback = function()
-						textviewer:onClose()
-					end
-				},
-				{
-					text = _("Overwrite"),
-					callback = function()
-						browser.sync_force = true
-						browser.sync_skip = false
-						textviewer:onClose()
-						for _, entry in ipairs(duplicate_list) do
-							table.insert(dl_list, entry)
-						end
-						Trapper:wrap(function()
-							DownloadManager.downloadPendingSyncs(browser, dl_list)
-						end)
-					end
-				},
-				{
-					text = _("Skip Duplicates"),
-					callback = function()
-						browser.sync_force = false
-						browser.sync_skip = true
-						textviewer:onClose()
-						Trapper:wrap(function()
-							DownloadManager.downloadPendingSyncs(browser, dl_list)
-						end)
-					end
-				},
-				{
-					text = _("Download copies"),
-					callback = function()
-						browser.sync_force = true
-						browser.sync_skip = false
-						textviewer:onClose()
-						local copies_dir = "copies"
-						local original_dir = util.splitFilePathName(duplicate_list[1].file)
-						local copy_download_dir = original_dir .. copies_dir .. "/"
-						util.makePath(copy_download_dir)
+  local textviewer
+  textviewer = TextViewer:new {
+    title = _("Duplicate files"),
+    text = text,
+    buttons_table = {
+      {
+        {
+          text = _("Do nothing"),
+          callback = function()
+            textviewer:onClose()
+          end
+        },
+        {
+          text = _("Overwrite"),
+          callback = function()
+            browser.sync_force = true
+            browser.sync_skip = false
+            textviewer:onClose()
+            for _, entry in ipairs(duplicate_list) do
+              table.insert(dl_list, entry)
+            end
+            Trapper:wrap(function()
+              DownloadManager.downloadPendingSyncs(browser, dl_list)
+            end)
+          end
+        },
+        {
+          text = _("Skip Duplicates"),
+          callback = function()
+            browser.sync_force = false
+            browser.sync_skip = true
+            textviewer:onClose()
+            Trapper:wrap(function()
+              DownloadManager.downloadPendingSyncs(browser, dl_list)
+            end)
+          end
+        },
+        {
+          text = _("Download copies"),
+          callback = function()
+            browser.sync_force = true
+            browser.sync_skip = false
+            textviewer:onClose()
+            local copies_dir = "copies"
+            local original_dir = util.splitFilePathName(duplicate_list[1].file)
+            local copy_download_dir = original_dir .. copies_dir .. "/"
+            util.makePath(copy_download_dir)
 
-						for _, entry in ipairs(duplicate_list) do
-							local _, file_name = util.splitFilePathName(entry.file)
-							local copy_download_path = copy_download_dir .. file_name
-							entry.file = copy_download_path
-							table.insert(dl_list, entry)
-						end
+            for _, entry in ipairs(duplicate_list) do
+              local _, file_name = util.splitFilePathName(entry.file)
+              local copy_download_path = copy_download_dir .. file_name
+              entry.file = copy_download_path
+              table.insert(dl_list, entry)
+            end
 
-						Trapper:wrap(function()
-							DownloadManager.downloadPendingSyncs(browser, dl_list)
-						end)
-					end
-				},
-			},
-		},
-	}
-	UIManager:show(textviewer)
+            Trapper:wrap(function()
+              DownloadManager.downloadPendingSyncs(browser, dl_list)
+            end)
+          end
+        },
+      },
+    },
+  }
+  UIManager:show(textviewer)
 end
 
 return SyncManager

--- a/main.lua
+++ b/main.lua
@@ -24,310 +24,310 @@ local SettingsDialogs = require("ui.dialogs.settings_dialogs")
 local StateManager = require("core.state_manager")
 
 local OPDS = WidgetContainer:extend {
-    name = "opdsplus",
-    opds_settings_file = DataStorage:getSettingsDir() .. "/opdsplus.lua",
-    settings = nil,
-    servers = nil,
-    downloads = nil,
+  name = "opdsplus",
+  opds_settings_file = DataStorage:getSettingsDir() .. "/opdsplus.lua",
+  settings = nil,
+  servers = nil,
+  downloads = nil,
 }
 
 function OPDS:init()
-    -- Initialize settings
-    local settings_manager = Settings:new(self.opds_settings_file)
-    self.opds_settings = settings_manager.storage
-    self.settings = settings_manager.data
+  -- Initialize settings
+  local settings_manager = Settings:new(self.opds_settings_file)
+  self.opds_settings = settings_manager.storage
+  self.settings = settings_manager.data
 
-    -- Initialize defaults
-    settings_manager:initializeDefaults()
+  -- Initialize defaults
+  settings_manager:initializeDefaults()
 
-    if settings_manager.is_first_run then
-        self.updated = true -- first run, force flush
-    end
+  if settings_manager.is_first_run then
+    self.updated = true     -- first run, force flush
+  end
 
-    -- Initialize state manager singleton
-    StateManager.getInstance(self)
+  -- Initialize state manager singleton
+  StateManager.getInstance(self)
 
-    -- Load servers, downloads, and pending syncs
-    self.servers = self.opds_settings:readSetting("servers", Constants.DEFAULT_SERVERS)
-    self.downloads = self.opds_settings:readSetting("downloads", {})
-    self.pending_syncs = self.opds_settings:readSetting("pending_syncs", {})
+  -- Load servers, downloads, and pending syncs
+  self.servers = self.opds_settings:readSetting("servers", Constants.DEFAULT_SERVERS)
+  self.downloads = self.opds_settings:readSetting("downloads", {})
+  self.pending_syncs = self.opds_settings:readSetting("pending_syncs", {})
 
-    self:onDispatcherRegisterActions()
-    self.ui.menu:registerToMainMenu(self)
+  self:onDispatcherRegisterActions()
+  self.ui.menu:registerToMainMenu(self)
 end
 
 function OPDS:getCoverHeightRatio()
-    return self.settings.cover_height_ratio or Constants.DEFAULT_COVER_HEIGHT_RATIO
+  return self.settings.cover_height_ratio or Constants.DEFAULT_COVER_HEIGHT_RATIO
 end
 
 function OPDS:setCoverHeightRatio(ratio, preset_name)
-    self.settings.cover_height_ratio = ratio
-    self.settings.cover_size_preset = preset_name or "Custom"
-    self.opds_settings:saveSetting("settings", self.settings)
-    self.opds_settings:flush()
+  self.settings.cover_height_ratio = ratio
+  self.settings.cover_size_preset = preset_name or "Custom"
+  self.opds_settings:saveSetting("settings", self.settings)
+  self.opds_settings:flush()
 end
 
 function OPDS:getCurrentPresetName()
-    return self.settings.cover_size_preset or "Regular"
+  return self.settings.cover_size_preset or "Regular"
 end
 
 function OPDS:saveSetting(key, value)
-    self.settings[key] = value
-    self.opds_settings:saveSetting("settings", self.settings)
-    self.opds_settings:flush()
+  self.settings[key] = value
+  self.opds_settings:saveSetting("settings", self.settings)
+  self.opds_settings:flush()
 end
 
 function OPDS:getSetting(key)
-    if self.settings[key] ~= nil then
-        return self.settings[key]
-    end
-    return Constants.DEFAULT_FONT_SETTINGS[key]
+  if self.settings[key] ~= nil then
+    return self.settings[key]
+  end
+  return Constants.DEFAULT_FONT_SETTINGS[key]
 end
 
 function OPDS:getAvailableFonts()
-    local fonts = {}
+  local fonts = {}
 
-    -- Add KOReader's built-in UI fonts first
-    table.insert(fonts, { name = "Default UI (Noto Sans)", value = "smallinfofont" })
-    table.insert(fonts, { name = "Alternative UI", value = "infofont" })
+  -- Add KOReader's built-in UI fonts first
+  table.insert(fonts, { name = "Default UI (Noto Sans)", value = "smallinfofont" })
+  table.insert(fonts, { name = "Alternative UI", value = "infofont" })
 
-    -- Scan font directories for available fonts
-    local font_dirs = {
-        "./fonts", -- KOReader's font directory
-    }
+  -- Scan font directories for available fonts
+  local font_dirs = {
+    "./fonts",     -- KOReader's font directory
+  }
 
-    -- Add user's font directory if it exists
-    local user_font_dir = DataStorage:getDataDir() .. "/fonts"
-    if lfs.attributes(user_font_dir, "mode") == "directory" then
-        table.insert(font_dirs, user_font_dir)
-    end
+  -- Add user's font directory if it exists
+  local user_font_dir = DataStorage:getDataDir() .. "/fonts"
+  if lfs.attributes(user_font_dir, "mode") == "directory" then
+    table.insert(font_dirs, user_font_dir)
+  end
 
-    local font_extensions = {
-        [".ttf"] = true,
-        [".otf"] = true,
-        [".ttc"] = true,
-    }
+  local font_extensions = {
+    [".ttf"] = true,
+    [".otf"] = true,
+    [".ttc"] = true,
+  }
 
-    -- Scan directories for font files
-    local seen_fonts = {}
-    for i, font_dir in ipairs(font_dirs) do
-        if lfs.attributes(font_dir, "mode") == "directory" then
-            for entry in lfs.dir(font_dir) do
-                if entry ~= "." and entry ~= ".." then
-                    local path = font_dir .. "/" .. entry
-                    local mode = lfs.attributes(path, "mode")
+  -- Scan directories for font files
+  local seen_fonts = {}
+  for i, font_dir in ipairs(font_dirs) do
+    if lfs.attributes(font_dir, "mode") == "directory" then
+      for entry in lfs.dir(font_dir) do
+        if entry ~= "." and entry ~= ".." then
+          local path = font_dir .. "/" .. entry
+          local mode = lfs.attributes(path, "mode")
 
-                    -- Check if it's a font file
-                    if mode == "file" then
-                        local ext = entry:match("%.([^.]+)$")
-                        if ext then
-                            ext = "." .. ext:lower()
-                            if font_extensions[ext] then
-                                local font_name = entry:match("^(.+)%.")
-                                if font_name and not seen_fonts[font_name] then
-                                    seen_fonts[font_name] = true
-                                    local display_name = font_name:gsub("%-", " "):gsub("_", " ")
-                                    table.insert(fonts, {
-                                        name = display_name,
-                                        value = font_name,
-                                    })
-                                end
-                            end
-                        end
-                        -- Also check subdirectories
-                    elseif mode == "directory" then
-                        local subdir_path = path
-                        for subentry in lfs.dir(subdir_path) do
-                            if subentry ~= "." and subentry ~= ".." then
-                                local subpath = subdir_path .. "/" .. subentry
-                                if lfs.attributes(subpath, "mode") == "file" then
-                                    local ext = subentry:match("%.([^.]+)$")
-                                    if ext then
-                                        ext = "." .. ext:lower()
-                                        if font_extensions[ext] then
-                                            local font_name = subentry:match("^(.+)%.")
-                                            if font_name and not seen_fonts[font_name] then
-                                                seen_fonts[font_name] = true
-                                                local display_name = font_name:gsub("%-", " "):gsub("_", " ")
-                                                table.insert(fonts, {
-                                                    name = display_name,
-                                                    value = font_name,
-                                                })
-                                            end
-                                        end
-                                    end
-                                end
-                            end
-                        end
-                    end
+          -- Check if it's a font file
+          if mode == "file" then
+            local ext = entry:match("%.([^.]+)$")
+            if ext then
+              ext = "." .. ext:lower()
+              if font_extensions[ext] then
+                local font_name = entry:match("^(.+)%.")
+                if font_name and not seen_fonts[font_name] then
+                  seen_fonts[font_name] = true
+                  local display_name = font_name:gsub("%-", " "):gsub("_", " ")
+                  table.insert(fonts, {
+                    name = display_name,
+                    value = font_name,
+                  })
                 end
+              end
             end
+            -- Also check subdirectories
+          elseif mode == "directory" then
+            local subdir_path = path
+            for subentry in lfs.dir(subdir_path) do
+              if subentry ~= "." and subentry ~= ".." then
+                local subpath = subdir_path .. "/" .. subentry
+                if lfs.attributes(subpath, "mode") == "file" then
+                  local ext = subentry:match("%.([^.]+)$")
+                  if ext then
+                    ext = "." .. ext:lower()
+                    if font_extensions[ext] then
+                      local font_name = subentry:match("^(.+)%.")
+                      if font_name and not seen_fonts[font_name] then
+                        seen_fonts[font_name] = true
+                        local display_name = font_name:gsub("%-", " "):gsub("_", " ")
+                        table.insert(fonts, {
+                          name = display_name,
+                          value = font_name,
+                        })
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
         end
+      end
     end
+  end
 
-    -- Sort alphabetically by display name
-    table.sort(fonts, function(a, b) return a.name < b.name end)
+  -- Sort alphabetically by display name
+  table.sort(fonts, function(a, b) return a.name < b.name end)
 
-    return fonts
+  return fonts
 end
 
 function OPDS:onDispatcherRegisterActions()
-    Dispatcher:registerAction("opdsplus_show_catalog",
-        { category = "none", event = "ShowOPDSPlusCatalog", title = _("OPDS Plus Catalog"), filemanager = true, }
-    )
+  Dispatcher:registerAction("opdsplus_show_catalog",
+    { category = "none", event = "ShowOPDSPlusCatalog", title = _("OPDS++ Catalog"), filemanager = true, }
+  )
 
-    Dispatcher:registerAction("opdsplus_sync_all",
-        { category = "none", event = "StartOPDSSyncAllCatalogs", title = _("OPDS Plus: Sync all catalogs (verify dups)"), filemanager = true, }
-    )
+  Dispatcher:registerAction("opdsplus_sync_all",
+    { category = "none", event = "StartOPDSSyncAllCatalogs", title = _("OPDS++: Sync all catalogs (verify dups)"), filemanager = true, }
+  )
 
-    Dispatcher:registerAction("opdsplus_sync_all_skip",
-        { category = "none", event = "StartOPDSSkipSyncAllCatalogs", title = _("OPDS Plus: Sync all catalogs (skip dups)"), filemanager = true, }
-    )
+  Dispatcher:registerAction("opdsplus_sync_all_skip",
+    { category = "none", event = "StartOPDSSkipSyncAllCatalogs", title = _("OPDS++: Sync all catalogs (skip dups)"), filemanager = true, }
+  )
 
-    Dispatcher:registerAction("opdsplus_force_sync_all",
-        { category = "none", event = "StartOPDSForceSyncAllCatalogs", title = _("OPDS Plus: Force sync all catalogs"), filemanager = true, }
-    )
+  Dispatcher:registerAction("opdsplus_force_sync_all",
+    { category = "none", event = "StartOPDSForceSyncAllCatalogs", title = _("OPDS++: Force sync all catalogs"), filemanager = true, }
+  )
 end
 
 function OPDS:_createBrowserInstance()
-    return OPDSBrowser:new {
-        servers = self.servers,
-        downloads = self.downloads,
-        settings = self.settings,
-        pending_syncs = self.pending_syncs,
-        title = _("OPDS Plus Catalog"),
-        is_popout = false,
-        is_borderless = true,
-        title_bar_fm_style = true,
-        show_covers = true,
-        _manager = self,
-        file_downloaded_callback = function(file)
-            self:showFileDownloadedDialog(file)
-        end,
-        close_callback = function()
-            if self.opds_browser.download_list then
-                self.opds_browser.download_list.close_callback()
-            end
-            UIManager:close(self.opds_browser)
-            self.opds_browser = nil
-            if self.last_downloaded_file then
-                if self.ui.file_chooser then
-                    local pathname = util.splitFilePathName(self.last_downloaded_file)
-                    self.ui.file_chooser:changeToPath(pathname, self.last_downloaded_file)
-                end
-                self.last_downloaded_file = nil
-            end
-        end,
-    }
+  return OPDSBrowser:new {
+    servers = self.servers,
+    downloads = self.downloads,
+    settings = self.settings,
+    pending_syncs = self.pending_syncs,
+    title = _("OPDS++ Catalog"),
+    is_popout = false,
+    is_borderless = true,
+    title_bar_fm_style = true,
+    show_covers = true,
+    _manager = self,
+    file_downloaded_callback = function(file)
+      self:showFileDownloadedDialog(file)
+    end,
+    close_callback = function()
+      if self.opds_browser.download_list then
+        self.opds_browser.download_list.close_callback()
+      end
+      UIManager:close(self.opds_browser)
+      self.opds_browser = nil
+      if self.last_downloaded_file then
+        if self.ui.file_chooser then
+          local pathname = util.splitFilePathName(self.last_downloaded_file)
+          self.ui.file_chooser:changeToPath(pathname, self.last_downloaded_file)
+        end
+        self.last_downloaded_file = nil
+      end
+    end,
+  }
 end
 
-function OPDS:_startSyncFromDispatcher(force_sync,skip_sync)
-    -- For gesture-triggered actions, create an off-screen browser context if needed.
-    if not self.opds_browser then
-        self.opds_browser = self:_createBrowserInstance()
-    end
+function OPDS:_startSyncFromDispatcher(force_sync, skip_sync)
+  -- For gesture-triggered actions, create an off-screen browser context if needed.
+  if not self.opds_browser then
+    self.opds_browser = self:_createBrowserInstance()
+  end
 
-    self.opds_browser.sync_force = force_sync
-    self.opds_browser.sync_skip = skip_sync
-    self.opds_browser:checkSyncDownload()
+  self.opds_browser.sync_force = force_sync
+  self.opds_browser.sync_skip = skip_sync
+  self.opds_browser:checkSyncDownload()
 end
 
 function OPDS:onStartOPDSSyncAllCatalogs()
-    self:_startSyncFromDispatcher(false, false)
+  self:_startSyncFromDispatcher(false, false)
 end
 
 function OPDS:onStartOPDSForceSyncAllCatalogs()
-    self:_startSyncFromDispatcher(true, false)
+  self:_startSyncFromDispatcher(true, false)
 end
 
 function OPDS:onStartOPDSSkipSyncAllCatalogs()
-    self:_startSyncFromDispatcher(false, true)
+  self:_startSyncFromDispatcher(false, true)
 end
 
 function OPDS:addToMainMenu(menu_items)
-    if not self.ui.document then -- FileManager menu only
-        menu_items.opdsplus = {
-            text = _("OPDS Plus Catalog"),
-            sub_item_table = SettingsMenu.create(self)
-        }
-    end
+  if not self.ui.document then   -- FileManager menu only
+    menu_items.opdsplus = {
+      text = _("OPDS++ Catalog"),
+      sub_item_table = SettingsMenu.create(self)
+    }
+  end
 end
 
 function OPDS:showCoverSizeMenu()
-    SettingsDialogs.showCoverSizeMenu(self)
+  SettingsDialogs.showCoverSizeMenu(self)
 end
 
 function OPDS:showCustomSizeDialog()
-    SettingsDialogs.showCustomSizeDialog(self)
+  SettingsDialogs.showCustomSizeDialog(self)
 end
 
 function OPDS:showFontSelectionMenu(setting_key, title)
-    SettingsDialogs.showFontSelectionMenu(self, setting_key, title)
+  SettingsDialogs.showFontSelectionMenu(self, setting_key, title)
 end
 
 function OPDS:showSizeSelectionMenu(setting_key, title, min_size, max_size, default_size)
-    SettingsDialogs.showSizeSelectionMenu(self, setting_key, title, min_size, max_size, default_size)
+  SettingsDialogs.showSizeSelectionMenu(self, setting_key, title, min_size, max_size, default_size)
 end
 
 function OPDS:showGridLayoutMenu()
-    SettingsDialogs.showGridLayoutMenu(self)
+  SettingsDialogs.showGridLayoutMenu(self)
 end
 
 function OPDS:showGridColumnsMenu()
-    SettingsDialogs.showGridColumnsMenu(self)
+  SettingsDialogs.showGridColumnsMenu(self)
 end
 
 function OPDS:showGridBorderMenu()
-    SettingsDialogs.showGridBorderMenu(self)
+  SettingsDialogs.showGridBorderMenu(self)
 end
 
 function OPDS:showGridBorderSizeMenu()
-    SettingsDialogs.showGridBorderSizeMenu(self)
+  SettingsDialogs.showGridBorderSizeMenu(self)
 end
 
 function OPDS:showGridBorderColorMenu()
-    SettingsDialogs.showGridBorderColorMenu(self)
+  SettingsDialogs.showGridBorderColorMenu(self)
 end
 
 function OPDS:showCoverCacheSizeDialog()
-    SettingsDialogs.showCoverCacheSizeDialog(self)
+  SettingsDialogs.showCoverCacheSizeDialog(self)
 end
 
 function OPDS:showCoverCacheTTLDialog()
-    SettingsDialogs.showCoverCacheTTLDialog(self)
+  SettingsDialogs.showCoverCacheTTLDialog(self)
 end
 
 function OPDS:clearCoverCache()
-    SettingsDialogs.clearCoverCache()
+  SettingsDialogs.clearCoverCache()
 end
 
 function OPDS:onShowOPDSPlusCatalog()
-    self.opds_browser = self:_createBrowserInstance()
-    UIManager:show(self.opds_browser)
+  self.opds_browser = self:_createBrowserInstance()
+  UIManager:show(self.opds_browser)
 end
 
 function OPDS:showFileDownloadedDialog(file)
-    self.last_downloaded_file = file
-    UIManager:show(ConfirmBox:new {
-        text = T(_("File saved to:\n%1\nWould you like to read the downloaded book now?"), BD.filepath(file)),
-        ok_text = _("Read now"),
-        ok_callback = function()
-            self.last_downloaded_file = nil
-            self.opds_browser.close_callback()
-            if self.ui.document then
-                self.ui:switchDocument(file)
-            else
-                self.ui:openFile(file)
-            end
-        end,
-    })
+  self.last_downloaded_file = file
+  UIManager:show(ConfirmBox:new {
+    text = T(_("File saved to:\n%1\nWould you like to read the downloaded book now?"), BD.filepath(file)),
+    ok_text = _("Read now"),
+    ok_callback = function()
+      self.last_downloaded_file = nil
+      self.opds_browser.close_callback()
+      if self.ui.document then
+        self.ui:switchDocument(file)
+      else
+        self.ui:openFile(file)
+      end
+    end,
+  })
 end
 
 function OPDS:onFlushSettings()
-    if self.updated then
-        self.opds_settings:flush()
-        self.updated = nil
-    end
+  if self.updated then
+    self.opds_settings:flush()
+    self.updated = nil
+  end
 end
 
 return OPDS

--- a/main.lua
+++ b/main.lua
@@ -41,7 +41,7 @@ function OPDS:init()
   settings_manager:initializeDefaults()
 
   if settings_manager.is_first_run then
-    self.updated = true     -- first run, force flush
+    self.updated = true -- first run, force flush
   end
 
   -- Initialize state manager singleton
@@ -93,7 +93,7 @@ function OPDS:getAvailableFonts()
 
   -- Scan font directories for available fonts
   local font_dirs = {
-    "./fonts",     -- KOReader's font directory
+    "./fonts", -- KOReader's font directory
   }
 
   -- Add user's font directory if it exists
@@ -245,9 +245,10 @@ function OPDS:onStartOPDSSkipSyncAllCatalogs()
 end
 
 function OPDS:addToMainMenu(menu_items)
-  if not self.ui.document then   -- FileManager menu only
+  if not self.ui.document then -- FileManager menu only
     menu_items.opdsplus = {
       text = _("OPDS++ Catalog"),
+      sorting_hint = "search",
       sub_item_table = SettingsMenu.create(self)
     }
   end

--- a/main.lua
+++ b/main.lua
@@ -177,7 +177,7 @@ function OPDS:onDispatcherRegisterActions()
     )
 
     Dispatcher:registerAction("opdsplus_sync_all",
-        { category = "none", event = "StartOPDSSyncAllCatalogs", title = _("OPDS Plus: Sync all catalogs (verify_dups)"), filemanager = true, }
+        { category = "none", event = "StartOPDSSyncAllCatalogs", title = _("OPDS Plus: Sync all catalogs (verify dups)"), filemanager = true, }
     )
 
     Dispatcher:registerAction("opdsplus_sync_all_skip",

--- a/main.lua
+++ b/main.lua
@@ -177,7 +177,11 @@ function OPDS:onDispatcherRegisterActions()
     )
 
     Dispatcher:registerAction("opdsplus_sync_all",
-        { category = "none", event = "StartOPDSSyncAllCatalogs", title = _("OPDS Plus: Sync all catalogs"), filemanager = true, }
+        { category = "none", event = "StartOPDSSyncAllCatalogs", title = _("OPDS Plus: Sync all catalogs (verify_dups)"), filemanager = true, }
+    )
+
+    Dispatcher:registerAction("opdsplus_sync_all_skip",
+        { category = "none", event = "StartOPDSSkipSyncAllCatalogs", title = _("OPDS Plus: Sync all catalogs (skip dups)"), filemanager = true, }
     )
 
     Dispatcher:registerAction("opdsplus_force_sync_all",
@@ -217,22 +221,27 @@ function OPDS:_createBrowserInstance()
     }
 end
 
-function OPDS:_startSyncFromDispatcher(force_sync)
+function OPDS:_startSyncFromDispatcher(force_sync,skip_sync)
     -- For gesture-triggered actions, create an off-screen browser context if needed.
     if not self.opds_browser then
         self.opds_browser = self:_createBrowserInstance()
     end
 
     self.opds_browser.sync_force = force_sync
+    self.opds_browser.sync_skip = skip_sync
     self.opds_browser:checkSyncDownload()
 end
 
 function OPDS:onStartOPDSSyncAllCatalogs()
-    self:_startSyncFromDispatcher(false)
+    self:_startSyncFromDispatcher(false, false)
 end
 
 function OPDS:onStartOPDSForceSyncAllCatalogs()
-    self:_startSyncFromDispatcher(true)
+    self:_startSyncFromDispatcher(true, false)
+end
+
+function OPDS:onStartOPDSSkipSyncAllCatalogs()
+    self:_startSyncFromDispatcher(false, true)
 end
 
 function OPDS:addToMainMenu(menu_items)

--- a/ui/browser.lua
+++ b/ui/browser.lua
@@ -314,16 +314,29 @@ function OPDSBrowser:onMenuHold(item)
                         UIManager:close(dialog)
                         NetworkMgr:runWhenConnected(function()
                             self.sync_force = true
+                            self.sync_skip = false
                             self:checkSyncDownload(item.idx)
                         end)
                     end,
                 },
                 {
-                    text = _("Sync"),
+                    text = _("Sync (skip dups)"),
                     callback = function()
                         UIManager:close(dialog)
                         NetworkMgr:runWhenConnected(function()
                             self.sync_force = false
+                            self.sync_skip = true
+                            self:checkSyncDownload(item.idx)
+                        end)
+                    end,
+                },
+                {
+                    text = _("Sync (verify)"),
+                    callback = function()
+                        UIManager:close(dialog)
+                        NetworkMgr:runWhenConnected(function()
+                            self.sync_force = false
+                            self.sync_skip = false
                             self:checkSyncDownload(item.idx)
                         end)
                     end,

--- a/ui/dialogs/menu_builder.lua
+++ b/ui/dialogs/menu_builder.lua
@@ -34,11 +34,24 @@ function OPDSMenuBuilder.buildOPDSMenu(browser)
 			} },
 			{},
 			{ {
-				text = _("Sync all catalogs"),
+				text = _("Sync all catalogs (skip dups)"),
 				callback = function()
 					UIManager:close(dialog)
 					NetworkMgr:runWhenConnected(function()
 						browser.sync_force = false
+						browser.sync_skip = true
+						browser:checkSyncDownload()
+					end)
+				end,
+				align = "left",
+			} },
+			{ {
+				text = _("Sync all catalogs (verify dups)"),
+				callback = function()
+					UIManager:close(dialog)
+					NetworkMgr:runWhenConnected(function()
+						browser.sync_force = false
+						browser.sync_skip = false
 						browser:checkSyncDownload()
 					end)
 				end,
@@ -50,6 +63,7 @@ function OPDSMenuBuilder.buildOPDSMenu(browser)
 					UIManager:close(dialog)
 					NetworkMgr:runWhenConnected(function()
 						browser.sync_force = true
+						browser.sync_skip = false
 						browser:checkSyncDownload()
 					end)
 				end,

--- a/ui/dialogs/settings_dialogs.lua
+++ b/ui/dialogs/settings_dialogs.lua
@@ -1,4 +1,4 @@
--- Settings dialog builders for OPDS Plus
+-- Settings dialog builders for OPDS++
 -- Extracted from main.lua for better organization and maintainability
 
 local ButtonDialogBuilder = require("utils.button_dialog_builder")
@@ -15,85 +15,85 @@ local SettingsDialogs = {}
 --- Show cover size preset selection menu
 -- @param plugin table Plugin instance (OPDS main)
 function SettingsDialogs.showCoverSizeMenu(plugin)
-	local current_preset = plugin:getCurrentPresetName()
-	local current_ratio = plugin:getCoverHeightRatio()
+  local current_preset = plugin:getCurrentPresetName()
+  local current_ratio = plugin:getCoverHeightRatio()
 
-	local builder = ButtonDialogBuilder:new()
-		:setTitle(_("Cover Size Settings\n\nSelect a preset or choose custom size"))
+  local builder = ButtonDialogBuilder:new()
+      :setTitle(_("Cover Size Settings\n\nSelect a preset or choose custom size"))
 
-	-- Add preset buttons with checkmarks and descriptions
-	local presets = Constants.COVER_SIZE_PRESETS
-	for i = 1, #presets do
-		local preset = presets[i]
-		local is_current = (current_preset == preset.name)
-		local button_text = preset.name .. " - " .. preset.description
-		if is_current then
-			button_text = "✓ " .. button_text
-		end
+  -- Add preset buttons with checkmarks and descriptions
+  local presets = Constants.COVER_SIZE_PRESETS
+  for i = 1, #presets do
+    local preset = presets[i]
+    local is_current = (current_preset == preset.name)
+    local button_text = preset.name .. " - " .. preset.description
+    if is_current then
+      button_text = "✓ " .. button_text
+    end
 
-		builder:addButton(button_text, function()
-			UIManager:close(plugin.cover_size_dialog)
-			plugin:setCoverHeightRatio(preset.ratio, preset.name)
-			UIManager:show(InfoMessage:new {
-				text = T(_("Cover size set to %1 (%2%).\n\n%3\n\nChanges will apply when you next browse a catalog."),
-					preset.name,
-					math.floor(preset.ratio * 100),
-					preset.description),
-				timeout = 3,
-			})
-		end)
-	end
+    builder:addButton(button_text, function()
+      UIManager:close(plugin.cover_size_dialog)
+      plugin:setCoverHeightRatio(preset.ratio, preset.name)
+      UIManager:show(InfoMessage:new {
+        text = T(_("Cover size set to %1 (%2%).\n\n%3\n\nChanges will apply when you next browse a catalog."),
+          preset.name,
+          math.floor(preset.ratio * 100),
+          preset.description),
+        timeout = 3,
+      })
+    end)
+  end
 
-	builder:addSeparator()
+  builder:addSeparator()
 
-	-- Add custom option
-	local custom_button_text = "Custom"
-	if current_preset == "Custom" then
-		custom_button_text = "✓ " .. custom_button_text .. " (" .. math.floor(current_ratio * 100) .. "%)"
-	end
+  -- Add custom option
+  local custom_button_text = "Custom"
+  if current_preset == "Custom" then
+    custom_button_text = "✓ " .. custom_button_text .. " (" .. math.floor(current_ratio * 100) .. "%)"
+  end
 
-	builder:addButton(custom_button_text, function()
-		UIManager:close(plugin.cover_size_dialog)
-		SettingsDialogs.showCustomSizeDialog(plugin)
-	end)
+  builder:addButton(custom_button_text, function()
+    UIManager:close(plugin.cover_size_dialog)
+    SettingsDialogs.showCustomSizeDialog(plugin)
+  end)
 
-	plugin.cover_size_dialog = builder:build()
-	UIManager:show(plugin.cover_size_dialog)
+  plugin.cover_size_dialog = builder:build()
+  UIManager:show(plugin.cover_size_dialog)
 end
 
 --- Show custom cover size spinner dialog
 -- @param plugin table Plugin instance (OPDS main)
 function SettingsDialogs.showCustomSizeDialog(plugin)
-	local current_ratio = plugin:getCoverHeightRatio()
-	local current_percent = math.floor(current_ratio * 100)
-	local spin_widget
-	spin_widget = SpinWidget:new {
-		title_text = _("Custom Cover Size"),
-		info_text = _("Adjust the size of book covers as a percentage of screen height.\n\n• Smaller values = more books per page\n• Larger values = bigger covers, fewer books per page\n\nRecommended: 8-12% for compact, 15-20% for large"),
-		value = current_percent,
-		value_min = 5,
-		value_max = 25,
-		value_step = 1,
-		value_hold_step = 5,
-		unit = "%",
-		ok_text = _("Apply"),
-		default_value = 10,
-		callback = function(spin)
-			local new_ratio = spin.value / 100
-			plugin:setCoverHeightRatio(new_ratio, "Custom")
-			UIManager:show(InfoMessage:new {
-				text = T(_("Cover size set to Custom (%1%).\n\nChanges will apply when you next browse a catalog."),
-					spin.value),
-				timeout = 3,
-			})
-		end,
-		extra_text = _("Back to Presets"),
-		extra_callback = function()
-			UIManager:close(spin_widget)
-			SettingsDialogs.showCoverSizeMenu(plugin)
-		end,
-	}
-	UIManager:show(spin_widget)
+  local current_ratio = plugin:getCoverHeightRatio()
+  local current_percent = math.floor(current_ratio * 100)
+  local spin_widget
+  spin_widget = SpinWidget:new {
+    title_text = _("Custom Cover Size"),
+    info_text = _("Adjust the size of book covers as a percentage of screen height.\n\n• Smaller values = more books per page\n• Larger values = bigger covers, fewer books per page\n\nRecommended: 8-12% for compact, 15-20% for large"),
+    value = current_percent,
+    value_min = 5,
+    value_max = 25,
+    value_step = 1,
+    value_hold_step = 5,
+    unit = "%",
+    ok_text = _("Apply"),
+    default_value = 10,
+    callback = function(spin)
+      local new_ratio = spin.value / 100
+      plugin:setCoverHeightRatio(new_ratio, "Custom")
+      UIManager:show(InfoMessage:new {
+        text = T(_("Cover size set to Custom (%1%).\n\nChanges will apply when you next browse a catalog."),
+          spin.value),
+        timeout = 3,
+      })
+    end,
+    extra_text = _("Back to Presets"),
+    extra_callback = function()
+      UIManager:close(spin_widget)
+      SettingsDialogs.showCoverSizeMenu(plugin)
+    end,
+  }
+  UIManager:show(spin_widget)
 end
 
 --- Show font selection menu
@@ -101,39 +101,39 @@ end
 -- @param setting_key string Setting key (e.g., "title_font")
 -- @param title string Dialog title
 function SettingsDialogs.showFontSelectionMenu(plugin, setting_key, title)
-	local current_font = plugin:getSetting(setting_key)
-	local available_fonts = plugin:getAvailableFonts()
+  local current_font = plugin:getSetting(setting_key)
+  local available_fonts = plugin:getAvailableFonts()
 
-	local builder = ButtonDialogBuilder:new()
-		:setTitle(T(_("%1 Selection\n\nChoose a font"), title))
+  local builder = ButtonDialogBuilder:new()
+      :setTitle(T(_("%1 Selection\n\nChoose a font"), title))
 
-	-- Add fonts with checkmarks, with separators every 5 items
-	for i, font_info in ipairs(available_fonts) do
-		local is_current = (current_font == font_info.value)
-		local button_text = font_info.name
-		if is_current then
-			button_text = "✓ " .. button_text
-		end
+  -- Add fonts with checkmarks, with separators every 5 items
+  for i, font_info in ipairs(available_fonts) do
+    local is_current = (current_font == font_info.value)
+    local button_text = font_info.name
+    if is_current then
+      button_text = "✓ " .. button_text
+    end
 
-		builder:addButton(button_text, function()
-			UIManager:close(plugin.font_dialog)
-			plugin:saveSetting(setting_key, font_info.value)
-			UIManager:show(InfoMessage:new {
-				text = T(_("%1 set to:\n%2\n\nChanges will apply when you next browse a catalog."),
-					title,
-					font_info.name),
-				timeout = 3,
-			})
-		end)
+    builder:addButton(button_text, function()
+      UIManager:close(plugin.font_dialog)
+      plugin:saveSetting(setting_key, font_info.value)
+      UIManager:show(InfoMessage:new {
+        text = T(_("%1 set to:\n%2\n\nChanges will apply when you next browse a catalog."),
+          title,
+          font_info.name),
+        timeout = 3,
+      })
+    end)
 
-		-- Add separator every 5 items for readability
-		if i % 5 == 0 and i < #available_fonts then
-			builder:addSeparator()
-		end
-	end
+    -- Add separator every 5 items for readability
+    if i % 5 == 0 and i < #available_fonts then
+      builder:addSeparator()
+    end
+  end
 
-	plugin.font_dialog = builder:build()
-	UIManager:show(plugin.font_dialog)
+  plugin.font_dialog = builder:build()
+  UIManager:show(plugin.font_dialog)
 end
 
 --- Show font size selection spinner
@@ -144,323 +144,323 @@ end
 -- @param max_size number Maximum font size
 -- @param default_size number Default font size
 function SettingsDialogs.showSizeSelectionMenu(plugin, setting_key, title, min_size, max_size, default_size)
-	local current_size = plugin:getSetting(setting_key)
+  local current_size = plugin:getSetting(setting_key)
 
-	local spin_widget = SpinWidget:new {
-		title_text = title,
-		info_text = _("Adjust the font size.\n\nChanges will apply when you next browse a catalog."),
-		value = current_size,
-		value_min = min_size,
-		value_max = max_size,
-		value_step = 1,
-		value_hold_step = 2,
-		unit = "pt",
-		ok_text = _("Apply"),
-		default_value = default_size,
-		callback = function(spin)
-			plugin:saveSetting(setting_key, spin.value)
-			UIManager:show(InfoMessage:new {
-				text = T(_("%1 set to %2pt.\n\nChanges will apply when you next browse a catalog."),
-					title,
-					spin.value),
-				timeout = 2,
-			})
-		end,
-	}
-	UIManager:show(spin_widget)
+  local spin_widget = SpinWidget:new {
+    title_text = title,
+    info_text = _("Adjust the font size.\n\nChanges will apply when you next browse a catalog."),
+    value = current_size,
+    value_min = min_size,
+    value_max = max_size,
+    value_step = 1,
+    value_hold_step = 2,
+    unit = "pt",
+    ok_text = _("Apply"),
+    default_value = default_size,
+    callback = function(spin)
+      plugin:saveSetting(setting_key, spin.value)
+      UIManager:show(InfoMessage:new {
+        text = T(_("%1 set to %2pt.\n\nChanges will apply when you next browse a catalog."),
+          title,
+          spin.value),
+        timeout = 2,
+      })
+    end,
+  }
+  UIManager:show(spin_widget)
 end
 
 --- Show grid layout preset menu
 -- @param plugin table Plugin instance
 function SettingsDialogs.showGridLayoutMenu(plugin)
-	local current_columns = plugin.settings.grid_columns or 3
-	local current_preset = plugin.settings.grid_size_preset or "Balanced"
+  local current_columns = plugin.settings.grid_columns or 3
+  local current_preset = plugin.settings.grid_size_preset or "Balanced"
 
-	local presets = {
-		{ name = "Compact",  columns = 4, desc = _("More books per page, smaller covers") },
-		{ name = "Balanced", columns = 3, desc = _("Good balance of size and quantity") },
-		{ name = "Spacious", columns = 2, desc = _("Fewer books, larger covers") },
-	}
+  local presets = {
+    { name = "Compact",  columns = 4, desc = _("More books per page, smaller covers") },
+    { name = "Balanced", columns = 3, desc = _("Good balance of size and quantity") },
+    { name = "Spacious", columns = 2, desc = _("Fewer books, larger covers") },
+  }
 
-	local builder = ButtonDialogBuilder:new()
-		:setTitle(_("Grid Layout Presets\n\nChoose how books are displayed in grid view"))
+  local builder = ButtonDialogBuilder:new()
+      :setTitle(_("Grid Layout Presets\n\nChoose how books are displayed in grid view"))
 
-	-- Add preset buttons
-	for i, preset in ipairs(presets) do
-		local is_current = (current_preset == preset.name and current_columns == preset.columns)
-		local button_text = preset.name .. " (" .. preset.columns .. " " .. _("cols") .. ")"
-		if is_current then
-			button_text = "✓ " .. button_text
-		end
+  -- Add preset buttons
+  for i, preset in ipairs(presets) do
+    local is_current = (current_preset == preset.name and current_columns == preset.columns)
+    local button_text = preset.name .. " (" .. preset.columns .. " " .. _("cols") .. ")"
+    if is_current then
+      button_text = "✓ " .. button_text
+    end
 
-		builder:addButton(button_text, function()
-			UIManager:close(plugin.grid_layout_dialog)
-			plugin.settings.grid_columns = preset.columns
-			plugin.settings.grid_size_preset = preset.name
-			plugin.opds_settings:saveSetting("settings", plugin.settings)
-			plugin.opds_settings:flush()
-			UIManager:show(InfoMessage:new {
-				text = T(_("Grid layout set to %1\n\n%2\n\nChanges will apply when you next browse a catalog in grid view."),
-					preset.name, preset.desc),
-				timeout = 2.5,
-			})
-		end)
-	end
+    builder:addButton(button_text, function()
+      UIManager:close(plugin.grid_layout_dialog)
+      plugin.settings.grid_columns = preset.columns
+      plugin.settings.grid_size_preset = preset.name
+      plugin.opds_settings:saveSetting("settings", plugin.settings)
+      plugin.opds_settings:flush()
+      UIManager:show(InfoMessage:new {
+        text = T(_("Grid layout set to %1\n\n%2\n\nChanges will apply when you next browse a catalog in grid view."),
+          preset.name, preset.desc),
+        timeout = 2.5,
+      })
+    end)
+  end
 
-	builder:addSeparator()
+  builder:addSeparator()
 
-	-- Custom option
-	local custom_text = _("Custom")
-	local is_custom = (current_preset ~= "Compact" and current_preset ~= "Balanced" and current_preset ~= "Spacious")
-	if is_custom then
-		custom_text = "✓ " .. custom_text .. " (" .. current_columns .. " " .. _("cols") .. ")"
-	end
+  -- Custom option
+  local custom_text = _("Custom")
+  local is_custom = (current_preset ~= "Compact" and current_preset ~= "Balanced" and current_preset ~= "Spacious")
+  if is_custom then
+    custom_text = "✓ " .. custom_text .. " (" .. current_columns .. " " .. _("cols") .. ")"
+  end
 
-	builder:addButton(custom_text, function()
-		UIManager:close(plugin.grid_layout_dialog)
-		SettingsDialogs.showGridColumnsMenu(plugin)
-	end)
+  builder:addButton(custom_text, function()
+    UIManager:close(plugin.grid_layout_dialog)
+    SettingsDialogs.showGridColumnsMenu(plugin)
+  end)
 
-	plugin.grid_layout_dialog = builder:build()
-	UIManager:show(plugin.grid_layout_dialog)
+  plugin.grid_layout_dialog = builder:build()
+  UIManager:show(plugin.grid_layout_dialog)
 end
 
 --- Show custom grid columns menu
 -- @param plugin table Plugin instance
 function SettingsDialogs.showGridColumnsMenu(plugin)
-	local current_columns = plugin.settings.grid_columns or 3
+  local current_columns = plugin.settings.grid_columns or 3
 
-	local builder = ButtonDialogBuilder:new()
-		:setTitle(_("Custom Grid Columns\n\nManually choose column count"))
+  local builder = ButtonDialogBuilder:new()
+      :setTitle(_("Custom Grid Columns\n\nManually choose column count"))
 
-	for cols = 2, 4 do
-		local is_current = (current_columns == cols)
-		local button_text = tostring(cols)
-		if cols == 2 then
-			button_text = button_text .. " " .. _("columns (wider)")
-		elseif cols == 3 then
-			button_text = button_text .. " " .. _("columns (balanced)")
-		else
-			button_text = button_text .. " " .. _("columns (compact)")
-		end
+  for cols = 2, 4 do
+    local is_current = (current_columns == cols)
+    local button_text = tostring(cols)
+    if cols == 2 then
+      button_text = button_text .. " " .. _("columns (wider)")
+    elseif cols == 3 then
+      button_text = button_text .. " " .. _("columns (balanced)")
+    else
+      button_text = button_text .. " " .. _("columns (compact)")
+    end
 
-		if is_current then
-			button_text = "✓ " .. button_text
-		end
+    if is_current then
+      button_text = "✓ " .. button_text
+    end
 
-		builder:addButton(button_text, function()
-			UIManager:close(plugin.grid_columns_dialog)
-			plugin.settings.grid_columns = cols
-			plugin.settings.grid_size_preset = "Custom"
-			plugin.opds_settings:saveSetting("settings", plugin.settings)
-			plugin.opds_settings:flush()
-			UIManager:show(InfoMessage:new {
-				text = T(_("Grid columns set to %1 (Custom).\n\nChanges will apply when you next browse a catalog in grid mode."), cols),
-				timeout = 2,
-			})
-		end)
-	end
+    builder:addButton(button_text, function()
+      UIManager:close(plugin.grid_columns_dialog)
+      plugin.settings.grid_columns = cols
+      plugin.settings.grid_size_preset = "Custom"
+      plugin.opds_settings:saveSetting("settings", plugin.settings)
+      plugin.opds_settings:flush()
+      UIManager:show(InfoMessage:new {
+        text = T(_("Grid columns set to %1 (Custom).\n\nChanges will apply when you next browse a catalog in grid mode."), cols),
+        timeout = 2,
+      })
+    end)
+  end
 
-	builder:addSeparator()
-	builder:addBackButton("← " .. _("Back to Presets"), function()
-		UIManager:close(plugin.grid_columns_dialog)
-		SettingsDialogs.showGridLayoutMenu(plugin)
-	end)
+  builder:addSeparator()
+  builder:addBackButton("← " .. _("Back to Presets"), function()
+    UIManager:close(plugin.grid_columns_dialog)
+    SettingsDialogs.showGridLayoutMenu(plugin)
+  end)
 
-	plugin.grid_columns_dialog = builder:build()
-	UIManager:show(plugin.grid_columns_dialog)
+  plugin.grid_columns_dialog = builder:build()
+  UIManager:show(plugin.grid_columns_dialog)
 end
 
 --- Show grid border style menu
 -- @param plugin table Plugin instance
 function SettingsDialogs.showGridBorderMenu(plugin)
-	local current_style = plugin.settings.grid_border_style or "none"
-	local current_size = plugin.settings.grid_border_size or 2
-	local current_color = plugin.settings.grid_border_color or "dark_gray"
+  local current_style = plugin.settings.grid_border_style or "none"
+  local current_size = plugin.settings.grid_border_size or 2
+  local current_color = plugin.settings.grid_border_color or "dark_gray"
 
-	local styles = {
-		{ id = "none",       name = _("No Borders"),       desc = _("Clean, borderless grid") },
-		{ id = "hash",       name = _("Hash Grid"),        desc = _("Shared borders like # pattern") },
-		{ id = "individual", name = _("Individual Tiles"), desc = _("Each book has its own border") },
-	}
+  local styles = {
+    { id = "none",       name = _("No Borders"),       desc = _("Clean, borderless grid") },
+    { id = "hash",       name = _("Hash Grid"),        desc = _("Shared borders like # pattern") },
+    { id = "individual", name = _("Individual Tiles"), desc = _("Each book has its own border") },
+  }
 
-	local builder = ButtonDialogBuilder:new()
-		:setTitle(_("Grid Border Settings\n\nCustomize the appearance of grid borders"))
-		:addLabel(_("Border Style"))
+  local builder = ButtonDialogBuilder:new()
+      :setTitle(_("Grid Border Settings\n\nCustomize the appearance of grid borders"))
+      :addLabel(_("Border Style"))
 
-	-- Add style options
-	builder:addOptionsWithCheckmarkAndDesc(styles, current_style, function(style)
-		UIManager:close(plugin.grid_border_dialog)
-		plugin.settings.grid_border_style = style.id
-		plugin.opds_settings:saveSetting("settings", plugin.settings)
-		plugin.opds_settings:flush()
-		UIManager:show(InfoMessage:new {
-			text = T(_("Border style set to: %1\n\n%2\n\nChanges will apply when you next browse a catalog in grid view."),
-				style.name, style.desc),
-			timeout = 2.5,
-		})
-	end)
+  -- Add style options
+  builder:addOptionsWithCheckmarkAndDesc(styles, current_style, function(style)
+    UIManager:close(plugin.grid_border_dialog)
+    plugin.settings.grid_border_style = style.id
+    plugin.opds_settings:saveSetting("settings", plugin.settings)
+    plugin.opds_settings:flush()
+    UIManager:show(InfoMessage:new {
+      text = T(_("Border style set to: %1\n\n%2\n\nChanges will apply when you next browse a catalog in grid view."),
+        style.name, style.desc),
+      timeout = 2.5,
+    })
+  end)
 
-	builder:addSeparator()
+  builder:addSeparator()
 
-	-- Border Customization (only if not "none")
-	if current_style ~= "none" then
-		builder:addLabel(_("Customize Borders"))
+  -- Border Customization (only if not "none")
+  if current_style ~= "none" then
+    builder:addLabel(_("Customize Borders"))
 
-		-- Border Size
-		builder:addButton(T(_("Border Thickness: %1px"), current_size), function()
-			UIManager:close(plugin.grid_border_dialog)
-			SettingsDialogs.showGridBorderSizeMenu(plugin)
-		end)
+    -- Border Size
+    builder:addButton(T(_("Border Thickness: %1px"), current_size), function()
+      UIManager:close(plugin.grid_border_dialog)
+      SettingsDialogs.showGridBorderSizeMenu(plugin)
+    end)
 
-		-- Border Color
-		local color_display = current_color == "dark_gray" and _("Dark Gray") or
-			current_color == "light_gray" and _("Light Gray") or
-			_("Black")
-		builder:addButton(T(_("Border Color: %1"), color_display), function()
-			UIManager:close(plugin.grid_border_dialog)
-			SettingsDialogs.showGridBorderColorMenu(plugin)
-		end)
-	end
+    -- Border Color
+    local color_display = current_color == "dark_gray" and _("Dark Gray") or
+        current_color == "light_gray" and _("Light Gray") or
+        _("Black")
+    builder:addButton(T(_("Border Color: %1"), color_display), function()
+      UIManager:close(plugin.grid_border_dialog)
+      SettingsDialogs.showGridBorderColorMenu(plugin)
+    end)
+  end
 
-	plugin.grid_border_dialog = builder:build()
-	UIManager:show(plugin.grid_border_dialog)
+  plugin.grid_border_dialog = builder:build()
+  UIManager:show(plugin.grid_border_dialog)
 end
 
 --- Show border thickness spinner
 -- @param plugin table Plugin instance
 function SettingsDialogs.showGridBorderSizeMenu(plugin)
-	local current_size = plugin.settings.grid_border_size or 2
-	local spin_widget
-	spin_widget = SpinWidget:new {
-		title_text = _("Border Thickness"),
-		info_text = _("Adjust the thickness of grid borders.\n\n• Thinner borders = more subtle\n• Thicker borders = more defined\n\nRecommended: 2-3px"),
-		value = current_size,
-		value_min = 1,
-		value_max = 5,
-		value_step = 1,
-		value_hold_step = 1,
-		unit = "px",
-		ok_text = _("Apply"),
-		default_value = 2,
-		callback = function(spin)
-			plugin.settings.grid_border_size = spin.value
-			plugin.opds_settings:saveSetting("settings", plugin.settings)
-			plugin.opds_settings:flush()
-			UIManager:show(InfoMessage:new {
-				text = T(_("Border thickness set to %1px.\n\nChanges will apply when you next browse a catalog in grid view."),
-					spin.value),
-				timeout = 2,
-			})
-		end,
-		extra_text = _("Back to Borders"),
-		extra_callback = function()
-			UIManager:close(spin_widget)
-			SettingsDialogs.showGridBorderMenu(plugin)
-		end,
-	}
-	UIManager:show(spin_widget)
+  local current_size = plugin.settings.grid_border_size or 2
+  local spin_widget
+  spin_widget = SpinWidget:new {
+    title_text = _("Border Thickness"),
+    info_text = _("Adjust the thickness of grid borders.\n\n• Thinner borders = more subtle\n• Thicker borders = more defined\n\nRecommended: 2-3px"),
+    value = current_size,
+    value_min = 1,
+    value_max = 5,
+    value_step = 1,
+    value_hold_step = 1,
+    unit = "px",
+    ok_text = _("Apply"),
+    default_value = 2,
+    callback = function(spin)
+      plugin.settings.grid_border_size = spin.value
+      plugin.opds_settings:saveSetting("settings", plugin.settings)
+      plugin.opds_settings:flush()
+      UIManager:show(InfoMessage:new {
+        text = T(_("Border thickness set to %1px.\n\nChanges will apply when you next browse a catalog in grid view."),
+          spin.value),
+        timeout = 2,
+      })
+    end,
+    extra_text = _("Back to Borders"),
+    extra_callback = function()
+      UIManager:close(spin_widget)
+      SettingsDialogs.showGridBorderMenu(plugin)
+    end,
+  }
+  UIManager:show(spin_widget)
 end
 
 --- Show border color selection menu
 -- @param plugin table Plugin instance
 function SettingsDialogs.showGridBorderColorMenu(plugin)
-	local current_color = plugin.settings.grid_border_color or "dark_gray"
+  local current_color = plugin.settings.grid_border_color or "dark_gray"
 
-	local colors = {
-		{ id = "light_gray", name = _("Light Gray"), desc = _("Subtle, minimal contrast") },
-		{ id = "dark_gray",  name = _("Dark Gray"),  desc = _("Balanced, clear definition") },
-		{ id = "black",      name = _("Black"),      desc = _("High contrast, bold borders") },
-	}
+  local colors = {
+    { id = "light_gray", name = _("Light Gray"), desc = _("Subtle, minimal contrast") },
+    { id = "dark_gray",  name = _("Dark Gray"),  desc = _("Balanced, clear definition") },
+    { id = "black",      name = _("Black"),      desc = _("High contrast, bold borders") },
+  }
 
-	local builder = ButtonDialogBuilder:new()
-		:setTitle(_("Border Color\n\nChoose the color for grid borders"))
+  local builder = ButtonDialogBuilder:new()
+      :setTitle(_("Border Color\n\nChoose the color for grid borders"))
 
-	builder:addOptionsWithCheckmarkAndDesc(colors, current_color, function(color)
-		UIManager:close(plugin.grid_border_color_dialog)
-		plugin.settings.grid_border_color = color.id
-		plugin.opds_settings:saveSetting("settings", plugin.settings)
-		plugin.opds_settings:flush()
-		UIManager:show(InfoMessage:new {
-			text = T(_("Border color set to: %1\n\n%2\n\nChanges will apply when you next browse a catalog in grid view."),
-				color.name, color.desc),
-			timeout = 2.5,
-		})
-	end)
+  builder:addOptionsWithCheckmarkAndDesc(colors, current_color, function(color)
+    UIManager:close(plugin.grid_border_color_dialog)
+    plugin.settings.grid_border_color = color.id
+    plugin.opds_settings:saveSetting("settings", plugin.settings)
+    plugin.opds_settings:flush()
+    UIManager:show(InfoMessage:new {
+      text = T(_("Border color set to: %1\n\n%2\n\nChanges will apply when you next browse a catalog in grid view."),
+        color.name, color.desc),
+      timeout = 2.5,
+    })
+  end)
 
-	builder:addSeparator()
-	builder:addBackButton("← " .. _("Back to Border Settings"), function()
-		UIManager:close(plugin.grid_border_color_dialog)
-		SettingsDialogs.showGridBorderMenu(plugin)
-	end)
+  builder:addSeparator()
+  builder:addBackButton("← " .. _("Back to Border Settings"), function()
+    UIManager:close(plugin.grid_border_color_dialog)
+    SettingsDialogs.showGridBorderMenu(plugin)
+  end)
 
-	plugin.grid_border_color_dialog = builder:build()
-	UIManager:show(plugin.grid_border_color_dialog)
+  plugin.grid_border_color_dialog = builder:build()
+  UIManager:show(plugin.grid_border_color_dialog)
 end
 
 --- Show cover cache size spinner (MB)
 -- @param plugin table Plugin instance
 function SettingsDialogs.showCoverCacheSizeDialog(plugin)
-	local current_mb = plugin:getSetting("cover_cache_max_mb") or Constants.COVER_CACHE.DEFAULT_MAX_MB
+  local current_mb = plugin:getSetting("cover_cache_max_mb") or Constants.COVER_CACHE.DEFAULT_MAX_MB
 
-	local spin_widget = SpinWidget:new {
-		title_text = _("Cover Cache Size"),
-		info_text = _("Set the maximum disk space used for cached cover images.\n\nLarger values improve offline reuse and reduce refetching after browsing."),
-		value = current_mb,
-		value_min = Constants.COVER_CACHE.MIN_MAX_MB,
-		value_max = Constants.COVER_CACHE.MAX_MAX_MB,
-		value_step = 8,
-		value_hold_step = 32,
-		unit = "MB",
-		ok_text = _("Apply"),
-		default_value = Constants.COVER_CACHE.DEFAULT_MAX_MB,
-		callback = function(spin)
-			plugin:saveSetting("cover_cache_max_mb", spin.value)
-			UIManager:show(InfoMessage:new {
-				text = T(_("Cover cache size set to %1 MB."), spin.value),
-				timeout = 2,
-			})
-		end,
-	}
+  local spin_widget = SpinWidget:new {
+    title_text = _("Cover Cache Size"),
+    info_text = _("Set the maximum disk space used for cached cover images.\n\nLarger values improve offline reuse and reduce refetching after browsing."),
+    value = current_mb,
+    value_min = Constants.COVER_CACHE.MIN_MAX_MB,
+    value_max = Constants.COVER_CACHE.MAX_MAX_MB,
+    value_step = 8,
+    value_hold_step = 32,
+    unit = "MB",
+    ok_text = _("Apply"),
+    default_value = Constants.COVER_CACHE.DEFAULT_MAX_MB,
+    callback = function(spin)
+      plugin:saveSetting("cover_cache_max_mb", spin.value)
+      UIManager:show(InfoMessage:new {
+        text = T(_("Cover cache size set to %1 MB."), spin.value),
+        timeout = 2,
+      })
+    end,
+  }
 
-	UIManager:show(spin_widget)
+  UIManager:show(spin_widget)
 end
 
 --- Show cover cache TTL spinner (minutes)
 -- @param plugin table Plugin instance
 function SettingsDialogs.showCoverCacheTTLDialog(plugin)
-	local current_ttl = plugin:getSetting("cover_cache_ttl_minutes") or Constants.COVER_CACHE.DEFAULT_TTL_MINUTES
+  local current_ttl = plugin:getSetting("cover_cache_ttl_minutes") or Constants.COVER_CACHE.DEFAULT_TTL_MINUTES
 
-	local spin_widget = SpinWidget:new {
-		title_text = _("Cover Cache TTL"),
-		info_text = _("Set how long cached covers remain fresh before revalidation by refetching.\n\nShorter TTL picks up changed covers sooner. Longer TTL reduces network requests."),
-		value = current_ttl,
-		value_min = Constants.COVER_CACHE.MIN_TTL_MINUTES,
-		value_max = Constants.COVER_CACHE.MAX_TTL_MINUTES,
-		value_step = 5,
-		value_hold_step = 60,
-		unit = _("min"),
-		ok_text = _("Apply"),
-		default_value = Constants.COVER_CACHE.DEFAULT_TTL_MINUTES,
-		callback = function(spin)
-			plugin:saveSetting("cover_cache_ttl_minutes", spin.value)
-			UIManager:show(InfoMessage:new {
-				text = T(_("Cover cache TTL set to %1 minutes."), spin.value),
-				timeout = 2,
-			})
-		end,
-	}
+  local spin_widget = SpinWidget:new {
+    title_text = _("Cover Cache TTL"),
+    info_text = _("Set how long cached covers remain fresh before revalidation by refetching.\n\nShorter TTL picks up changed covers sooner. Longer TTL reduces network requests."),
+    value = current_ttl,
+    value_min = Constants.COVER_CACHE.MIN_TTL_MINUTES,
+    value_max = Constants.COVER_CACHE.MAX_TTL_MINUTES,
+    value_step = 5,
+    value_hold_step = 60,
+    unit = _("min"),
+    ok_text = _("Apply"),
+    default_value = Constants.COVER_CACHE.DEFAULT_TTL_MINUTES,
+    callback = function(spin)
+      plugin:saveSetting("cover_cache_ttl_minutes", spin.value)
+      UIManager:show(InfoMessage:new {
+        text = T(_("Cover cache TTL set to %1 minutes."), spin.value),
+        timeout = 2,
+      })
+    end,
+  }
 
-	UIManager:show(spin_widget)
+  UIManager:show(spin_widget)
 end
 
 --- Clear disk cover cache
 function SettingsDialogs.clearCoverCache()
-	ImageLoader.clearCache()
-	UIManager:show(InfoMessage:new {
-		text = _("Cover cache cleared."),
-		timeout = 2,
-	})
+  ImageLoader.clearCache()
+  UIManager:show(InfoMessage:new {
+    text = _("Cover cache cleared."),
+    timeout = 2,
+  })
 end
 
 return SettingsDialogs

--- a/utils/debug.lua
+++ b/utils/debug.lua
@@ -1,4 +1,4 @@
--- Debug utility for OPDS Plus
+-- Debug utility for OPDS++
 -- Provides conditional debug logging based on StateManager settings
 
 local logger = require("logger")
@@ -7,15 +7,15 @@ local Debug = {}
 
 -- Lazy-load StateManager to avoid circular dependencies
 local function getStateManager()
-	local StateManager = require("core.state_manager")
-	return StateManager.getInstance()
+  local StateManager = require("core.state_manager")
+  return StateManager.getInstance()
 end
 
 --- Check if debug mode is enabled
 -- @return boolean True if debug mode is on
 local function isDebugEnabled()
-	local state = getStateManager()
-	return state:isDebugMode()
+  local state = getStateManager()
+  return state:isDebugMode()
 end
 
 --- Log debug message if debug mode is enabled (StateManager-based)
@@ -23,18 +23,18 @@ end
 -- @param prefix string Log prefix (e.g., "Browser:", "DownloadMgr:")
 -- @param ... any Values to log
 function Debug.log(prefix, ...)
-	if isDebugEnabled() then
-		logger.dbg("OPDS+", prefix, ...)
-	end
+  if isDebugEnabled() then
+    logger.dbg("OPDS+", prefix, ...)
+  end
 end
 
 --- Log warning message if debug mode is enabled
 -- @param prefix string Log prefix (e.g., "Browser:", "DownloadMgr:")
 -- @param ... any Values to log
 function Debug.warn(prefix, ...)
-	if isDebugEnabled() then
-		logger.warn("OPDS+", prefix, ...)
-	end
+  if isDebugEnabled() then
+    logger.warn("OPDS+", prefix, ...)
+  end
 end
 
 --- Log error message (always logs, regardless of debug mode)
@@ -42,7 +42,7 @@ end
 -- @param prefix string Log prefix (e.g., "Browser:", "DownloadMgr:")
 -- @param ... any Values to log
 function Debug.error(prefix, ...)
-	logger.warn("OPDS+ ERROR:", prefix, ...)
+  logger.warn("OPDS+ ERROR:", prefix, ...)
 end
 
 --- Legacy log function for backward compatibility
@@ -51,10 +51,10 @@ end
 -- @param prefix string Log prefix
 -- @param ... any Values to log
 function Debug.logCompat(manager, prefix, ...)
-	-- Ignore manager param, use StateManager
-	if isDebugEnabled() then
-		logger.dbg("OPDS+", prefix, ...)
-	end
+  -- Ignore manager param, use StateManager
+  if isDebugEnabled() then
+    logger.dbg("OPDS+", prefix, ...)
+  end
 end
 
 --- Create a debug logger function bound to a specific context
@@ -62,12 +62,12 @@ end
 -- @param context string Context identifier (e.g., "Browser", "DownloadMgr")
 -- @return function Debug logging function
 function Debug.createLogger(context)
-	local prefix = "[" .. context .. "]:"
-	return function(...)
-		if isDebugEnabled() then
-			logger.dbg("OPDS+", prefix, ...)
-		end
-	end
+  local prefix = "[" .. context .. "]:"
+  return function(...)
+    if isDebugEnabled() then
+      logger.dbg("OPDS+", prefix, ...)
+    end
+  end
 end
 
 --- Create a debug logger with method-style calling
@@ -75,29 +75,29 @@ end
 -- @param context string Context identifier
 -- @return table Object with logging methods
 function Debug.createContextLogger(context)
-	local prefix = "[" .. context .. "]:"
-	return {
-		--- Log debug message (only when debug mode enabled)
-		log = function(self, ...)
-			if isDebugEnabled() then
-				logger.dbg("OPDS+", prefix, ...)
-			end
-		end,
-		--- Log warning message (only when debug mode enabled)
-		warn = function(self, ...)
-			if isDebugEnabled() then
-				logger.warn("OPDS+", prefix, ...)
-			end
-		end,
-		--- Log error message (always logged)
-		error = function(self, ...)
-			logger.warn("OPDS+ ERROR:", prefix, ...)
-		end,
-		--- Check if debug is enabled (useful for expensive debug operations)
-		isEnabled = function()
-			return isDebugEnabled()
-		end,
-	}
+  local prefix = "[" .. context .. "]:"
+  return {
+    --- Log debug message (only when debug mode enabled)
+    log = function(self, ...)
+      if isDebugEnabled() then
+        logger.dbg("OPDS+", prefix, ...)
+      end
+    end,
+    --- Log warning message (only when debug mode enabled)
+    warn = function(self, ...)
+      if isDebugEnabled() then
+        logger.warn("OPDS+", prefix, ...)
+      end
+    end,
+    --- Log error message (always logged)
+    error = function(self, ...)
+      logger.warn("OPDS+ ERROR:", prefix, ...)
+    end,
+    --- Check if debug is enabled (useful for expensive debug operations)
+    isEnabled = function()
+      return isDebugEnabled()
+    end,
+  }
 end
 
 return Debug


### PR DESCRIPTION
# OPDS Plus Pull Request

Thanks for contributing to OPDS Plus!

## Summary

Offers a third option between force sync everything and sync nothing if the first opds item return matches an item in our library.

With OPDS server entries where you have saved the result of a search as your sync (against tags, for example), and the latest tagged item isn't necessarily the latest added item, this lets you still sync successfully without being forced to re-download your entire library.

## Type of change

- [ ] Bug fix
- [X] New feature
- [X] UI/UX improvement
- [ ] Refactor / code cleanup
- [ ] Documentation update

## Checklist

- [X] I have tested these changes on my device (or emulator)
- [X] I have checked for Lua errors in `crash.log`
- [X] I have updated the README/CHANGELOG if needed
- [X] I have kept changes focused and minimal

## Screenshots
Screenshots of menus before/after. The real sizzle is of course in that nothing is displayed if you sync ignoring dups, but that would be a boring screenshot of the emulator screen :) 

<img width="713" height="420" alt="Screenshot From 2026-03-29 14-34-56" src="https://github.com/user-attachments/assets/28070292-0ed5-4321-8067-e1f8cd99a791" />
<img width="713" height="420" alt="Screenshot From 2026-03-29 14-38-30" src="https://github.com/user-attachments/assets/e944774a-8b20-41fa-b6fe-ac62b54ce173" />
<img width="713" height="953" alt="Screenshot From 2026-03-29 14-38-59" src="https://github.com/user-attachments/assets/8aafdb96-e128-464b-95f3-56fa50ad5265" />
<img width="713" height="953" alt="Screenshot From 2026-03-29 14-41-45" src="https://github.com/user-attachments/assets/e5507626-4df7-470a-9a67-fac72643795e" />
<img width="713" height="953" alt="Screenshot From 2026-03-29 14-42-16" src="https://github.com/user-attachments/assets/f64118a8-9b42-4748-ba6f-5cb8781fb432" />
<img width="713" height="953" alt="Screenshot From 2026-03-29 14-42-31" src="https://github.com/user-attachments/assets/115f7b25-de5a-4509-84f3-8f98fedc972f" />

## Additional notes

My use case is that I have a COPS opds server running, and am currently using the SimpleUI plugin. SimpleUI lets you create custom screen buttons, and I have one mapped to the gesture for opdsplus sync. With this addition, that button is a one click, no interaction download of anything new in my sync dirs (which include a source that is a filtered tag search of just my TBR shelf). If the addition of the extra buttons is too much, this PR could be paired down to just offering the feature in the gesture menu. But since I had to add it everywhere else as is, I figured :shrug: 

