### PR TITLE
fix: cover cache on kindle devices

### DIFF
--- a/services/cover_cache.lua
+++ b/services/cover_cache.lua
@@ -4,7 +4,7 @@ local bit = require("bit")
 
 local CoverCache = {}
 
-local CACHE_DIR = DataStorage:getDataDir() .. "/cache/opds_plus/covers"
+local CACHE_DIR = DataStorage:getFullDataDir() .. "/cache/opds_plus/covers"
 
 local function ensureDir(path)
 	if lfs.attributes(path, "mode") == "directory" then


### PR DESCRIPTION
# OPDS Plus Pull Request

Thanks for contributing to OPDS Plus!

## Summary

Fixes silent cover cache failure on Kindle devices. DataStorage:getDataDir() returns a relative path (./) on Kindle, which resolves to the read-only install directory, causing lfs.mkdir to fail silently and covers never being cached.

The fix replaces getDataDir() with getFullDataDir(), which returns the absolute writable path (e.g. /mnt/us/koreader).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Refactor / code cleanup
- [ ] Documentation update

## Checklist

- [x] I have tested these changes on my device (or emulator)
- [x] I have checked for Lua errors in `crash.log`
- [x] I have updated the README/CHANGELOG if needed
- [x] I have kept changes focused and minimal

## Additional notes

Closes #86 
