### PR TITLE
Fetch catalog pages ahead of the reader, not on demand

### DIFF
--- a/ui/browser.lua
+++ b/ui/browser.lua
@@ -381,10 +381,9 @@ end
 
 -- Menu action on next-page chevron tap (request and show more catalog entries)
 function OPDSBrowser:onNextPage(fill_only)
-    -- self.page_num comes from menu.lua
-    local page_num = self.page_num
-    -- fetch more entries until we fill out one page or reach the end
-    while page_num == self.page_num do
+    -- Fetching blocks the UI, and a feed page holds several screens, so ask the server only
+    -- when running out: one page ahead, so the end is not felt. self.page_num comes from menu.lua.
+    while self.page + 2 > self.page_num do
         local hrefs = self.item_table.hrefs
         if hrefs and hrefs.next then
             if not self:appendCatalog(hrefs.next) then


### PR DESCRIPTION
`onNextPage` kept asking the server while the current page number had not moved,
so the fetch landed on the very page it was needed for and the reader waited for
it.

Fetching blocks the UI, and one feed page holds several screens. The request now
goes out while two screens still remain, so the catalog fills in before the
reader gets there.

Tested on a Kindle 3 against a multi-page catalog.
