### PR TITLE
Make the browser usable without a touchscreen

### DIFF
--- a/ui/browser.lua
+++ b/ui/browser.lua
@@ -1,6 +1,7 @@
 local BD = require("ui/bidi")
 local ButtonDialog = require("ui/widget/buttondialog")
 local ConfirmBox = require("ui/widget/confirmbox")
+local Device = require("device")
 local InfoMessage = require("ui/widget/infomessage")
 local Menu = require("ui/widget/menu")
 local NetworkMgr = require("ui/network/manager")
@@ -79,6 +80,19 @@ function OPDSBrowser:init()
     self.title_bar_right_icon = nil
     self.facet_groups = nil
     OPDSCoverMenu.init(self)
+
+    -- Menu maps the back key to Close; walk up the catalog instead, and leave Home to close.
+    if Device:hasKeys() then
+        self.key_events.Back = { { Device.input.group.Back } }
+        self.key_events.Close = { { "Home" } }
+    end
+end
+
+function OPDSBrowser:onBack()
+    if self.paths and #self.paths > 0 then
+        return self:onReturn()
+    end
+    return self:onClose()
 end
 
 function OPDSBrowser:_debugLog(...)
@@ -105,18 +119,29 @@ function OPDSBrowser:toggleViewMode()
         timeout = 1,
     })
 
-    -- Refresh the current view WITHOUT breaking navigation or auth context
-    if #self.paths > 0 then
-        -- We're in a catalog - get current URL
-        local current_path = self.paths[#self.paths]
-        local current_url = current_path.url
+    -- The views hold a different number of items per page, so remember the item, not the page.
+    local itemnumber = self:getFocusedItemNumber()
 
-        -- Reload the catalog with same URL
-        self:updateCatalog(current_url, true)
-    else
-        -- We're at root level - just switch the display mode
-        self:switchItemTable(self.catalog_title, self.item_table, -1)
+    self:switchItemTable(self.catalog_title, self.item_table, itemnumber)
+
+    -- switchItemTable paged with the old view's perpage and focused the first item.
+    local page = self:getPageNumber(itemnumber)
+    local select_number = itemnumber - ((page - 1) * self.perpage)
+    if page ~= self.page or select_number ~= 1 then
+        self.page = page
+        self:updateItems(select_number)
     end
+end
+
+--- Number of the focused item within the whole catalog, 1 if nothing is focused.
+function OPDSBrowser:getFocusedItemNumber()
+    local selected = self.selected
+    if not selected or not self.perpage then
+        return 1
+    end
+    local columns = (self.layout and self.layout[1]) and #self.layout[1] or 1
+    local in_page = ((selected.y - 1) * columns) + selected.x
+    return ((self.page - 1) * self.perpage) + in_page
 end
 
 function OPDSBrowser:showOPDSMenu()

--- a/ui/dialogs/book_info_dialog.lua
+++ b/ui/dialogs/book_info_dialog.lua
@@ -603,6 +603,15 @@ function BookInfoDialog.build(browser, item)
 		browser.book_info_dialog.movable,
 	}
 
+	-- The dialog did not exist yet where the table was built; FocusManager repaints show_parent.
+	button_table.show_parent = browser.book_info_dialog
+
+	if Device:hasKeys() then
+		browser.book_info_dialog.key_events = {
+			Close = { { Device.input.group.Back } },
+		}
+	end
+
 	-- Add close on tap outside
 	browser.book_info_dialog.ges_events = {
 		TapClose = {

--- a/ui/menus/grid_menu.lua
+++ b/ui/menus/grid_menu.lua
@@ -61,6 +61,14 @@ local GRID_CONFIG = {
     show_author = true,
 }
 
+-- Height the cell lays the text out in, so that the row is sized for what it really draws.
+local function textAreaHeight(title_size, info_size)
+    local title_height = math.ceil(title_size * 1.3) * GRID_CONFIG.title_lines_max
+    local author_height = GRID_CONFIG.show_author and math.ceil(info_size * 1.2) or 0
+    local title_author_gap = GRID_CONFIG.show_author and 4 or 0
+    return title_height + title_author_gap + author_height
+end
+
 -- Helper function to get border color
 local function getBorderColor(color_name)
     if color_name == "black" then
@@ -159,7 +167,7 @@ function OPDSGridCell:init()
 
     -- Calculate FIXED heights for uniform alignment across all cells
     local title_line_height = math.ceil(title_size * 1.3)
-    local title_fixed_height = title_line_height * 2
+    local title_fixed_height = title_line_height * GRID_CONFIG.title_lines_max
 
     local author_line_height = math.ceil(info_size * 1.2)
     local author_fixed_height = GRID_CONFIG.show_author and author_line_height or 0
@@ -167,9 +175,31 @@ function OPDSGridCell:init()
     local title_author_gap = GRID_CONFIG.show_author and 4 or 0
     local cover_text_gap = 6
 
-    local text_area_height = title_fixed_height + title_author_gap + author_fixed_height + cover_text_gap
+    local text_area_height = textAreaHeight(title_size, info_size)
 
-    local max_text_area = self.cell_height - self.cover_height - (GRID_CONFIG.cell_padding * 2)
+    local border_style = (self.border_settings and self.border_settings.style) or "none"
+    local border_size = (self.border_settings and self.border_settings.size) or 2
+    local border_color_name = (self.border_settings and self.border_settings.color) or "dark_gray"
+    local border_color = getBorderColor(border_color_name)
+
+    local cell_bordersize = 0
+    if border_style == "individual" then
+        cell_bordersize = border_size
+    end
+
+    -- The underline takes the cell's bottom padding, so the content keeps the room it had
+    -- and the grid keeps its rows per page.
+    local underline_size = math.min(Size.line.focus_indicator, GRID_CONFIG.cell_padding)
+    local underline_gap = math.min(Size.padding.tiny, GRID_CONFIG.cell_padding - underline_size)
+    local frame_height = self.cell_height - underline_size - underline_gap
+    local frame_padding_bottom = math.max(0, GRID_CONFIG.cell_padding - underline_size - underline_gap)
+
+    local inner_width = self.cell_width - (GRID_CONFIG.cell_padding * 2) - (cell_bordersize * 2)
+    local inner_height = frame_height - GRID_CONFIG.cell_padding - frame_padding_bottom
+        - (cell_bordersize * 2)
+
+    -- What the frame really leaves the text once the cover and its gap are placed.
+    local max_text_area = inner_height - self.cover_height - cover_text_gap
     text_area_height = math.min(text_area_height, max_text_area)
 
     -- Build text group with FIXED heights for each element
@@ -256,24 +286,6 @@ function OPDSGridCell:init()
         text_group,
     }
 
-    local border_style = (self.border_settings and self.border_settings.style) or "none"
-    local border_size = (self.border_settings and self.border_settings.size) or 2
-    local border_color_name = (self.border_settings and self.border_settings.color) or "dark_gray"
-    local border_color = getBorderColor(border_color_name)
-
-    local cell_bordersize = 0
-    if border_style == "individual" then
-        cell_bordersize = border_size
-    end
-
-    -- Eats into the cell rather than adding to it, so the grid keeps its rows per page.
-    local underline_size = math.min(Size.line.focus_indicator, GRID_CONFIG.cell_padding)
-    local underline_gap = math.min(Size.padding.tiny, GRID_CONFIG.cell_padding - underline_size)
-    local frame_height = self.cell_height - underline_size - underline_gap
-
-    local inner_width = self.cell_width - (GRID_CONFIG.cell_padding * 2) - (cell_bordersize * 2)
-    local inner_height = frame_height - (GRID_CONFIG.cell_padding * 2) - (cell_bordersize * 2)
-
     self._underline = LineWidget:new {
         dimen = Geom:new { w = self.cell_width, h = underline_size },
         background = self._is_focused and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_WHITE,
@@ -285,6 +297,7 @@ function OPDSGridCell:init()
             width = self.cell_width,
             height = frame_height,
             padding = GRID_CONFIG.cell_padding,
+            padding_bottom = frame_padding_bottom,
             margin = 0,
             bordersize = cell_bordersize,
             color = border_color,
@@ -426,10 +439,8 @@ function OPDSGridMenu:setGridDimensions()
     local info_size = font_settings.info_size or 12
 
     -- Calculate text area needed
-    local title_height = math.ceil(title_size * 2 * 1.3)
-    local author_height = GRID_CONFIG.show_author and math.ceil(info_size * 1.2) or 0
     local cover_text_gap = 6
-    local text_area_height = title_height + author_height + cover_text_gap
+    local text_area_height = textAreaHeight(title_size, info_size) + cover_text_gap
 
     -- Calculate how much height we need per row
     local spacing_between_rows = (target_rows - 1) * GRID_CONFIG.row_spacing
@@ -506,10 +517,8 @@ function OPDSGridMenu:_recalculateDimen()
         local title_size = font_settings.title_size or 14
         local info_size = font_settings.info_size or 12
 
-        local title_height = math.ceil(title_size * 2 * 1.3)
-        local author_height = GRID_CONFIG.show_author and math.ceil(info_size * 1.2) or 0
         local cover_text_gap = 6
-        local text_area_height = title_height + author_height + cover_text_gap
+        local text_area_height = textAreaHeight(title_size, info_size) + cover_text_gap
 
         local new_cover_height = new_cell_height - text_area_height - (GRID_CONFIG.cell_padding * 2) - border_deduction
 
@@ -760,30 +769,8 @@ function OPDSGridMenu:updateItems(select_number)
         return "ui", refresh_dimen
     end)
 
-    -- Custom page info
-    if self.page_info then
-        local custom_text = "▦ " .. self.page .. "/" .. self.page_num .. " (" .. self.perpage .. " items)"
-
-        for i = 1, 10 do
-            if self.page_info[i] and type(self.page_info[i]) == "table" and self.page_info[i].text then
-                local old_widget = self.page_info[i]
-                local face = old_widget.face or Font:getFace("smallinfofont")
-                local fgcolor = old_widget.fgcolor or Blitbuffer.COLOR_BLACK
-
-                if old_widget.free then
-                    old_widget:free()
-                end
-
-                self.page_info[i] = TextWidget:new {
-                    text = custom_text,
-                    face = face,
-                    fgcolor = fgcolor,
-                }
-
-                UIManager:setDirty(self.show_parent, "ui")
-                break
-            end
-        end
+    if self.page_info_text then
+        self.page_info_text:setText(OPDSGridMenu.getPageInfo(self))
     end
 
     -- Schedule cover loading

--- a/ui/menus/grid_menu.lua
+++ b/ui/menus/grid_menu.lua
@@ -10,6 +10,7 @@ local HorizontalSpan = require("ui/widget/horizontalspan")
 local ImageWidget = require("ui/widget/imagewidget")
 local InputContainer = require("ui/widget/container/inputcontainer")
 local Menu = require("ui/widget/menu")
+local Size = require("ui/size")
 local TextBoxWidget = require("ui/widget/textboxwidget")
 local TextWidget = require("ui/widget/textwidget")
 local UIManager = require("ui/uimanager")
@@ -265,32 +266,60 @@ function OPDSGridCell:init()
         cell_bordersize = border_size
     end
 
-    local inner_width = self.cell_width - (GRID_CONFIG.cell_padding * 2) - (cell_bordersize * 2)
-    local inner_height = self.cell_height - (GRID_CONFIG.cell_padding * 2) - (cell_bordersize * 2)
+    -- Eats into the cell rather than adding to it, so the grid keeps its rows per page.
+    local underline_size = math.min(Size.line.focus_indicator, GRID_CONFIG.cell_padding)
+    local underline_gap = math.min(Size.padding.tiny, GRID_CONFIG.cell_padding - underline_size)
+    local frame_height = self.cell_height - underline_size - underline_gap
 
-    self[1] = FrameContainer:new {
-        width = self.cell_width,
-        height = self.cell_height,
-        padding = GRID_CONFIG.cell_padding,
-        margin = 0,
-        bordersize = cell_bordersize,
-        color = border_color,
-        background = Blitbuffer.COLOR_WHITE,
-        CenterContainer:new {
-            dimen = Geom:new {
-                w = inner_width,
-                h = inner_height,
-            },
-            VerticalGroup:new {
-                align = "center",
-                cover_widget,
-                VerticalSpan:new { width = cover_text_gap },
-                text_container,
+    local inner_width = self.cell_width - (GRID_CONFIG.cell_padding * 2) - (cell_bordersize * 2)
+    local inner_height = frame_height - (GRID_CONFIG.cell_padding * 2) - (cell_bordersize * 2)
+
+    self._underline = LineWidget:new {
+        dimen = Geom:new { w = self.cell_width, h = underline_size },
+        background = self._is_focused and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_WHITE,
+    }
+
+    self[1] = VerticalGroup:new {
+        align = "left",
+        FrameContainer:new {
+            width = self.cell_width,
+            height = frame_height,
+            padding = GRID_CONFIG.cell_padding,
+            margin = 0,
+            bordersize = cell_bordersize,
+            color = border_color,
+            background = Blitbuffer.COLOR_WHITE,
+            CenterContainer:new {
+                dimen = Geom:new {
+                    w = inner_width,
+                    h = inner_height,
+                },
+                VerticalGroup:new {
+                    align = "center",
+                    cover_widget,
+                    VerticalSpan:new { width = cover_text_gap },
+                    text_container,
+                },
             },
         },
+        VerticalSpan:new { width = underline_gap },
+        self._underline,
     }
 
     self.cover_widget = cover_widget
+end
+
+-- The cell is rebuilt when its cover arrives, hence the flag init() restores the line from.
+function OPDSGridCell:onFocus()
+    self._is_focused = true
+    self._underline.background = Blitbuffer.COLOR_BLACK
+    return true
+end
+
+function OPDSGridCell:onUnfocus()
+    self._is_focused = false
+    self._underline.background = Blitbuffer.COLOR_WHITE
+    return true
 end
 
 function OPDSGridCell:update()
@@ -568,6 +597,7 @@ function OPDSGridMenu:updateItems(select_number)
         -- Create complete grid with hash borders
         for row = 1, rows_per_page do
             local row_group = HorizontalGroup:new { align = "top" }
+            local row_cells = {}
 
             if centering_offset > 0 then
                 table.insert(row_group, HorizontalSpan:new { width = centering_offset })
@@ -591,6 +621,7 @@ function OPDSGridMenu:updateItems(select_number)
                     }
 
                     table.insert(row_group, cell)
+                    table.insert(row_cells, cell)
 
                     if entry.cover_url and entry.lazy_load_cover and not entry.cover_bb then
                         table.insert(self._items_to_update, { entry = entry, widget = cell })
@@ -634,7 +665,9 @@ function OPDSGridMenu:updateItems(select_number)
             end
 
             table.insert(self.item_group, row_group)
-            table.insert(self.layout, { row_group })
+            if #row_cells > 0 then
+                table.insert(self.layout, row_cells)
+            end
 
             -- Add horizontal line between rows (but not after last)
             if row < rows_per_page then
@@ -665,6 +698,7 @@ function OPDSGridMenu:updateItems(select_number)
         -- Standard grid (none or individual borders)
         for row = 1, rows_per_page do
             local row_group = HorizontalGroup:new { align = "top" }
+            local row_cells = {}
 
             if centering_offset > 0 then
                 table.insert(row_group, HorizontalSpan:new { width = centering_offset })
@@ -688,6 +722,7 @@ function OPDSGridMenu:updateItems(select_number)
                     }
 
                     table.insert(row_group, cell)
+                    table.insert(row_cells, cell)
 
                     if entry.cover_url and entry.lazy_load_cover and not entry.cover_bb then
                         table.insert(self._items_to_update, { entry = entry, widget = cell })
@@ -706,7 +741,9 @@ function OPDSGridMenu:updateItems(select_number)
             end
 
             table.insert(self.item_group, row_group)
-            table.insert(self.layout, { row_group })
+            if #row_cells > 0 then
+                table.insert(self.layout, row_cells)
+            end
 
             if row < rows_per_page then
                 table.insert(self.item_group, VerticalSpan:new { width = GRID_CONFIG.row_spacing })

--- a/ui/menus/list_menu.lua
+++ b/ui/menus/list_menu.lua
@@ -546,36 +546,8 @@ function OPDSListMenu:updateItems(select_number)
         return "ui", refresh_dimen
     end)
 
-    -- Update page info with custom text
-    if self.page_info then
-        local custom_text = "≡ " .. self.page .. "/" .. self.page_num .. " (" .. self.perpage .. " items)"
-
-        -- Find and replace the text widget
-        for i = 1, 10 do
-            if self.page_info[i] and type(self.page_info[i]) == "table" and self.page_info[i].text then
-                -- Get the original widget's properties (with fallbacks)
-                local old_widget = self.page_info[i]
-                local face = old_widget.face or Font:getFace("smallinfofont")
-                local fgcolor = old_widget.fgcolor or Blitbuffer.COLOR_BLACK
-
-                -- Free the old widget
-                if old_widget.free then
-                    old_widget:free()
-                end
-
-                -- Create new TextWidget with updated text
-                self.page_info[i] = TextWidget:new {
-                    text = custom_text,
-                    face = face,
-                    fgcolor = fgcolor,
-                }
-
-                -- Mark dirty for full refresh
-                UIManager:setDirty(self.show_parent, "ui")
-
-                break
-            end
-        end
+    if self.page_info_text then
+        self.page_info_text:setText(OPDSListMenu.getPageInfo(self))
     end
 
     -- Schedule cover loading

--- a/ui/menus/list_menu.lua
+++ b/ui/menus/list_menu.lua
@@ -45,7 +45,8 @@ local COVER_CONFIG = {
 
     -- Spacing and padding
     item_top_padding = 6,
-    item_bottom_padding = 6,
+    -- Fits the focus underline plus clearance, so the last item's line stays off the footer.
+    item_bottom_padding = math.max(6, Size.line.focus_indicator + Size.padding.default + Size.padding.small),
     cover_left_margin = 6,
     cover_right_margin = 8,
 }
@@ -250,6 +251,15 @@ function OPDSListMenuItem:init()
 
     -- Assemble the complete item with proper spacing
     local TopContainer = require("ui/widget/container/topcontainer")
+    local LineWidget = require("ui/widget/linewidget")
+
+    -- Focus underline: white until focused, and it eats bottom padding instead of adding height.
+    local underline_size = math.min(Size.line.focus_indicator, bottom_padding)
+    local underline_gap = math.min(Size.padding.default, bottom_padding - underline_size)
+    self._underline = LineWidget:new {
+        dimen = Geom:new { w = self.width, h = underline_size },
+        background = self._is_focused and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_WHITE,
+    }
 
     self[1] = FrameContainer:new {
         width = self.width,
@@ -274,11 +284,26 @@ function OPDSListMenuItem:init()
                     text_group,
                 },
             },
-            VerticalSpan:new { width = bottom_padding },
+            VerticalSpan:new { width = bottom_padding - underline_size - underline_gap },
+            self._underline,
+            VerticalSpan:new { width = underline_gap },
         }
     }
 
     self.cover_widget = cover_widget
+end
+
+-- The item is rebuilt when its cover arrives, hence the flag init() restores the line from.
+function OPDSListMenuItem:onFocus()
+    self._is_focused = true
+    self._underline.background = Blitbuffer.COLOR_BLACK
+    return true
+end
+
+function OPDSListMenuItem:onUnfocus()
+    self._is_focused = false
+    self._underline.background = Blitbuffer.COLOR_WHITE
+    return true
 end
 
 function OPDSListMenuItem:update()


### PR DESCRIPTION
On a Kindle without a touchscreen (K3, 5-way and keyboard) the browser cannot
really be used: the list never shows where the focus is, the grid moves it a
whole row at a time, and back closes the browser outright, however deep in the
catalog you are.

Four commits:

- The focus is visible in the list and moves cell by cell in the grid. The
  indicator is an underline of `Size.line.focus_indicator`, the width KOReader
  marks focus with elsewhere, drawn clear of the footer.
- The page counter and the row height are left to `Menu`: both menus drew their
  own counter over the one Menu already places, and the grid reserved a fixed
  row height that did not match the text it draws, so long titles were clipped
  while short ones left a gap.
- Back closes the book info dialog, which previously could only be dismissed by
  tapping outside it, and moving between its buttons repaints only the dialog
  rather than the whole browser underneath.
- Back walks up one catalog level and only closes the browser at the root.
  Switching between list and grid keeps the position instead of jumping to the
  first page.

Tested on a Kindle 3.
